### PR TITLE
Fix(#4)/ 비밀번호 재설정 과정 이메일 전달 로직 및 UI 수정 #4

### DIFF
--- a/src/app/auth/signin/page.jsx
+++ b/src/app/auth/signin/page.jsx
@@ -28,12 +28,16 @@ export default function Page() {
   const [errors, setErrors] = useState([]);
   const [isRendering, setIsRendering] = useState(0);
   const [loading, setLoading] = useState(false);
+  const [verifiedEmail, setVerifiedEmail] = useState('');
 
   const handleBackToLogin = () => setIsRendering(0);
   const handleFindIdClick = () => setIsRendering(1);
   const handleResetPasswordClick = () => setIsRendering(2);
   const handleBackToResetRequest = () => setIsRendering(2);
-  const handleResetPasswordNext = () => setIsRendering(3);
+  const handleResetPasswordNext = (email) => {
+    setVerifiedEmail(email);
+    setIsRendering(3);
+  };
 
   const validatePassword = (password) => {
     const newErrors = [];
@@ -59,13 +63,13 @@ export default function Page() {
         setLoading(true);
         const res = await login(email, password);
         const { exists, access_token } = res.data.data;
-      
+
         if (!exists) {
           alert('아이디 혹은 비밀번호가 올바르지 않습니다.');
           setLoading(false);
           return;
         }
-      
+
         setAccessToken(access_token);
         router.push('/main');
       } catch (error) {
@@ -77,7 +81,7 @@ export default function Page() {
   };
 
   return (
-      <>
+    <>
       <Loader isLoading={loading} />
       <Image src={loginBg} alt='loginBg' fill className='absolute top-0 left-0 -z-10 object-cover opacity-70 blur-sm' />
       <div className='flex justify-center items-center flex-1 relative'>
@@ -120,9 +124,9 @@ export default function Page() {
               : `${isRendering === 3 ? '-translate-x-full' : 'translate-x-full'} opacity-0`
           } flex justify-center items-center`}
         >
-          <AuthResetRequest 
-            handleNextStep={handleResetPasswordNext} 
-            handleBackToLogin={handleBackToLogin} 
+          <AuthResetRequest
+            handleNextStep={handleResetPasswordNext}
+            handleBackToLogin={handleBackToLogin}
             setLoading={setLoading}
           />
         </div>
@@ -135,6 +139,7 @@ export default function Page() {
           } flex justify-center items-center`}
         >
           <AuthResetPassword
+            email={verifiedEmail}
             handleBackToLogin={handleBackToLogin}
             handleBackToResetRequest={handleBackToResetRequest}
             setLoading={setLoading}

--- a/src/components/auth/screen/AuthResetPassword.jsx
+++ b/src/components/auth/screen/AuthResetPassword.jsx
@@ -6,8 +6,7 @@ import axios from 'axios';
 
 import TransparentInput from '@/components/ui/input/TransparentInput';
 
-export default function AuthResetPassword({ handleBackToLogin, handleBackToResetRequest, setLoading }) {
-  const [email, setEmail] = useState('');
+export default function AuthResetPassword({ email, handleBackToLogin, handleBackToResetRequest, setLoading }) {
   const [newPassword, setNewPassword] = useState('');
   const [verifyNewPassword, setVerifyNewPassword] = useState('');
   const API_AUTH_URL = process.env.NEXT_PUBLIC_BASE_API_URL + '/auth';
@@ -44,34 +43,34 @@ export default function AuthResetPassword({ handleBackToLogin, handleBackToReset
         name='email'
         value={email}
         autoComplete={false}
-        onChange={(e) => setEmail(e.target.value)}
+        isDisabled={true}
         className='!mt-[40px]'
         label='이메일'
         placeholder='이메일을 입력해주세요'
       />
-      <TransparentInput 
+      <TransparentInput
         type='password'
         name='name'
         value={newPassword}
         autoComplete={false}
         onChange={(e) => setNewPassword(e.target.value)}
-        className='!mt-[40px]' 
-        label='새 비밀번호' 
-        placeholder='새 비밀번호를 입력해주세요' 
+        className='!mt-[40px]'
+        label='새 비밀번호'
+        placeholder='새 비밀번호를 입력해주세요'
       />
-      <TransparentInput 
+      <TransparentInput
         type='password'
         name='name'
         value={verifyNewPassword}
         autoComplete={false}
         onChange={(e) => setVerifyNewPassword(e.target.value)}
         className='!mt-[40px]'
-        label='새 비밀번호 확인' 
+        label='새 비밀번호 확인'
         placeholder='새 비밀번호를 확인'
       />
-      <Button 
-        color='primary' 
-        onPress={handleNewPassword} 
+      <Button
+        color='primary'
+        onPress={handleNewPassword}
         className='!mt-[20px] h-[48px] mobile:h-[44px] w-full rounded-full !bg-[#EA4336]'
       >
         비밀번호 변경

--- a/src/components/auth/screen/AuthResetRequest.jsx
+++ b/src/components/auth/screen/AuthResetRequest.jsx
@@ -84,25 +84,25 @@ export default function AuthResetRequest({ handleNextStep, handleBackToLogin, se
           isDisabled={!isNextDisabled}
         />
 
-        <Button 
-          onPress={handleSendOtp} 
+        <Button
+          onPress={handleSendOtp}
           isDisabled={!isNextDisabled}
-          color='default' 
+          color='default'
           className='!mt-[20px] h-[40px] mobile:h-[44px] w-full rounded-full !bg-[#DCDCDC]'
         >
           {isOtpDisabled ? '인증번호 보내기' : '인증번호 재전송'}
         </Button>
 
-        <OtpInput 
-          label='인증번호' 
-          setOtp={setOtp} 
+        <OtpInput
+          label='인증번호'
+          setOtp={setOtp}
           isDisabled={isOtpDisabled}
           isOtpVerified={!isNextDisabled}
           onSubmitOtp={handleVerifyOtp}
         />
 
         <Button
-          onPress={handleNextStep}
+          onPress={() => handleNextStep(email)}
           isDisabled={isNextDisabled}
           color='primary'
           className='!mt-[20px] h-[48px] mobile:h-[44px] w-full rounded-full !bg-[#EA4336]'


### PR DESCRIPTION
## #️⃣ Related Issue
#4 

## 📝 PR Description
비밀번호 재설정 과정에서 인증 완료 후 이메일 입력창에 다른 이메일을 보내면 다른 계정의 비밀번호가 수정되던 오류 수정

## ✅ 추후 TODO
악용해서 계정을 탈취해 갈 수 있는 기능인만큼 아직 보안에서 조금 부족한 부분이 있는 것 같아 아래와 같이 하면 어떨까 싶습니다! :

1. 비밀번호 재설정 인증 과정에서 백앤드에서 HttpOnly+SameSite 쿠키로 구성된 resetToken을 받기
2. confirm에서는 email을 받지 말고, 토큰만 검증해 이메일을 서버에서 식별해 비밀번호를 변경한 뒤 사용 후 토큰은 즉시 무효화하는 방식

 으로 보안향상을 하면 좋을 것 같습니다.

+) email은 비밀번호 재설정 화면에서 display 정도만

## Screenshots (선택)
-

## 💬 Reviewer Request (선택)
-