### PR TITLE
chore: Claude Code 하네스 도입 (CLAUDE.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,8 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# claude code (개인 설정만 제외)
+.claude/settings.local.json
+
 # ide files
 .idea

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# 프로젝트: GDGoC INHA 프론트엔드
+
+인하대학교 GDGoC 공식 웹사이트. 백엔드 API는 별도 리포(`GDGoCINHA/24-2_GDGoC_Server`, Spring Boot)에서 관리한다.
+
+## 기술 스택
+
+- Next.js 15 (App Router) — **`output: 'export'` 정적 사이트**
+- React 18.3 / TypeScript 5.9
+- Tailwind CSS 4 (`@tailwindcss/postcss`)
+- NextUI + HeroUI
+- axios (인증 클라이언트)
+- framer-motion, gsap, lenis (애니메이션)
+
+패키지 매니저는 **yarn**을 쓴다 (배포 워크플로우 기준).
+
+## 아키텍처 규칙
+
+- CRITICAL: **이 프로젝트에는 서버가 없다.** `next.config.ts`의 `output: 'export'`로 정적 파일을 생성해 S3에 올린다. SSR·ISR·Route Handler·미들웨어·서버 액션은 **동작하지 않는다.** 데이터는 클라이언트에서 백엔드 API를 직접 호출해 가져온다.
+- CRITICAL: 인증이 필요한 요청은 `src/lib/api/authorizedClient.ts`(axios) 또는 `authorizedFetch.ts`를 통한다. `axios`를 새로 생성해 직접 호출하지 않는다 — 토큰 주입과 401 재발급 인터셉터를 우회하게 된다.
+- CRITICAL: 백엔드 주소는 `NEXT_PUBLIC_BASE_API_URL`로 주입된다. **빌드 타임에 번들로 인라인되므로 런타임에 바꿀 수 없다.** 하드코딩하지 않는다.
+- 경로 별칭은 `@` → `src`, `@public` → `public` (`next.config.ts`의 webpack alias).
+- 컴포넌트는 `src/components/{도메인}/`, 공용 UI는 `src/components/ui/`에 둔다.
+- `trailingSlash: true`이므로 내부 링크 경로 끝에 슬래시가 붙는다.
+- 이미지는 `unoptimized: true` — `next/image` 최적화가 꺼져 있다.
+
+## 개발 프로세스
+
+- 커밋 메시지는 conventional commits를 따른다 (`feat:`, `fix:`, `refactor:`, `chore:`).
+- 브랜치는 `feature/{기능}` → `develop` → `master` 순으로 올린다.
+- 코드 스타일은 Prettier가 강제한다. 수정 후 `yarn format`을 실행한다.
+
+## 명령어
+
+```bash
+yarn dev            # 개발 서버
+yarn build          # 정적 빌드 (out/ 생성)
+yarn lint           # ESLint
+yarn format         # Prettier 적용
+yarn format:check   # 포맷 검사만
+```
+
+**테스트 스크립트는 없다.** 테스트 인프라가 구성돼 있지 않으므로 검증은 `yarn build`와 수동 확인에 의존한다.
+
+## ⚠️ 이 프로젝트의 함정
+
+코드만 읽어서는 드러나지 않는 것들. **작업 전에 반드시 인지할 것.**
+
+### `src/app/api/`는 죽은 코드다
+
+`route.ts` 4개가 있지만 전부 `POST` 핸들러다. **static export는 POST Route Handler를 지원하지 않으며**, 실제로 이들을 호출하는 코드도 리포에 없다.
+
+인증 흐름은 이 라우트가 아니라 `src/lib/api/`의 axios 클라이언트가 백엔드를 **직접 호출**하는 방식이다. 액세스 토큰은 localStorage에 저장하고 `Authorization: Bearer`로 보낸다.
+
+새 API 연동을 만들 때 이 디렉터리를 참고하지 마라. 동작하지 않는 패턴이다.
+
+### 운영 브랜치가 `master`다
+
+백엔드 리포는 `main`인데 **이 리포는 `master`**다. 헷갈리기 쉽다.
+
+| 브랜치 | 배포 대상 | `NEXT_PUBLIC_APP_ENV` |
+|---|---|---|
+| `develop` push | 개발 S3 버킷 | `dev` |
+| `master` push | **운영 S3 버킷** | `production` |
+
+머지가 곧 배포다. 승인 단계가 없으며, 빌드 후 S3 sync(`--delete`) → CloudFront 캐시 무효화까지 자동 실행된다.
+
+또한 **`develop`을 거치지 않고 `master`로 직접 머지되는 경우가 있다.** 그래서 `develop`이 `master`보다 뒤쳐져 있을 수 있다. 작업을 시작하기 전에 두 브랜치의 차이를 확인하라.
+
+```bash
+git log --oneline origin/develop..origin/master
+```
+
+### 패키지 매니저가 섞여 있다
+
+- `.github/workflows/deploy.yml` → **`yarn install --frozen-lockfile`** (실제 배포 경로)
+- `Dockerfile`, `buildspec.yml` → `npm install`
+
+`yarn.lock`과 `package-lock.json`이 **둘 다 존재**한다. 의존성을 추가할 때 yarn을 쓰면 `package-lock.json`이 뒤처지고, npm을 쓰면 배포 빌드와 어긋난다. **배포 기준인 yarn을 따르라.**
+
+### Docker 관련 파일은 과거 배포 방식의 잔재다
+
+`Dockerfile`, `docker-compose.yml`, `appspec.yml`, `buildspec.yml`은 2026-01 이후 방치돼 있고 **현재 배포 경로에서 쓰이지 않는다.** 실제 배포는 GitHub Actions → S3 → CloudFront다.
+
+배포 문제를 디버깅할 때 이 파일들을 보면 엉뚱한 곳을 파게 된다. `.github/workflows/deploy.yml`을 보라.
+
+### 백엔드 응답 형식
+
+모든 API는 다음 형태로 감싸여 온다. `data`를 바로 쓰지 말고 이 래퍼를 벗겨야 한다.
+
+```ts
+{ code: number, message: string, data: T, meta?: M }
+```
+
+`meta`에는 페이징 정보가 들어온다. `null` 필드는 응답에서 생략된다.


### PR DESCRIPTION
## 개요

AI 코딩 에이전트(Claude Code)가 이 코드베이스에서 작업할 때 필요한 맥락을 추가합니다. 코드 변경은 없습니다.

- `CLAUDE.md` — 기술 스택, 아키텍처 규칙, 이 프로젝트의 함정
- `.gitignore` — `.claude/settings.local.json` 제외 (개인 설정 유출 방지)

## 문서에 담은 것

에이전트에게 정말 필요한 정보는 코드를 읽어서 알 수 있는 것이 아니라 **읽어도 모르는 것**입니다. '함정' 절에 그런 항목을 모았습니다.

### `src/app/api/`는 죽은 코드입니다

`route.ts` 4개가 있지만 전부 `POST` 핸들러입니다. `output: 'export'`에서는 POST Route Handler가 지원되지 않고, 실제로 이들을 호출하는 코드도 리포에 없습니다.

인증은 이 라우트가 아니라 `src/lib/api/`의 axios 클라이언트가 백엔드를 직접 호출하는 방식입니다. **새 API 연동 시 이 디렉터리를 참고하면 동작하지 않는 패턴을 따라가게 됩니다.**

### 서버가 없다는 사실

`output: 'export'` 정적 사이트라 SSR·ISR·Route Handler·미들웨어·서버 액션이 모두 동작하지 않습니다. Next.js 15 App Router 프로젝트를 처음 보는 사람(또는 에이전트)은 당연히 서버가 있다고 가정하므로 명시했습니다.

### 패키지 매니저 혼재

- `.github/workflows/deploy.yml` → `yarn install --frozen-lockfile` (실제 배포 경로)
- `Dockerfile`, `buildspec.yml` → `npm install`

`yarn.lock`과 `package-lock.json`이 둘 다 존재합니다. 문서에는 **배포 기준인 yarn을 따르라**고 적었습니다.

### 죽은 배포 파일

`Dockerfile`, `docker-compose.yml`, `appspec.yml`, `buildspec.yml`은 2026-01 이후 방치돼 있고 현재 배포 경로(GitHub Actions → S3 → CloudFront)에서 쓰이지 않습니다. 배포 문제를 디버깅할 때 엉뚱한 곳을 파지 않도록 적었습니다.

### 운영 브랜치가 `master`

백엔드 리포는 `main`이라 혼동하기 쉽습니다. 또한 `develop`을 거치지 않고 `master`로 직접 머지되는 경우가 있어 `develop`이 뒤쳐질 수 있다는 점도 적었습니다 (현재 23커밋 차이).

## 훅은 넣지 않았습니다

`.claude/settings.json`(종료 시 자동 검증, 위험 명령 차단)은 백엔드 리포에는 추가했지만 여기엔 넣지 않았습니다. `node_modules`가 설치되지 않은 상태라 훅이 실제로 동작하는지 확인할 수 없었고, **검증하지 않은 훅은 없느니만 못하기 때문**입니다.

필요하면 후속 PR에서 추가할 수 있습니다.

## 정리 제안 (이 PR 범위 밖)

- `src/app/api/` 삭제 — 동작하지 않고 호출되지도 않습니다
- `Dockerfile`·`docker-compose.yml`·`appspec.yml`·`buildspec.yml` 삭제
- `package-lock.json` 또는 `yarn.lock` 중 하나로 정리
- `xjsconfig.json`, `xnext.config.mjs` — 접두사로 비활성화된 파일

문서화만 하고 삭제하지 않았습니다. 실제로 쓰이지 않는지 팀 확인이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011C6y8HJTXGsbKsdaHw6fQa
