### PR TITLE
feat: 2026-2 코어 모집 오픈 (진입 경로·기간 게이트)

### DIFF
--- a/src/app/recruit/core/completed/page.tsx
+++ b/src/app/recruit/core/completed/page.tsx
@@ -3,17 +3,7 @@
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { GdgLogo, GdgButton } from '@/components/ui/design-system'
-
-function Bullet({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="flex items-start w-full">
-      <span className="w-5 shrink-0 text-center text-[18px] mobile:text-[16px] leading-none font-bold mt-[1px]">
-        •
-      </span>
-      <div className="typo-pc-b2 mobile:typo-m-b3 flex-1">{children}</div>
-    </div>
-  )
-}
+import { RecruitScheduleCard } from '@/components/recruit/RecruitScheduleCard'
 
 export default function RecruitCoreCompleted() {
   const searchParams = useSearchParams()
@@ -30,7 +20,6 @@ export default function RecruitCoreCompleted() {
           </h1>
         </div>
 
-        {/* Content Sections - Step 2 UI 이관 */}
         <div className="col-span-4 flex flex-col gap-10 w-full">
           <div className="rounded-xl bg-gray-100 px-4 py-3 text-white typo-pc-b2 mobile:typo-m-b3">
             {isClosed
@@ -38,50 +27,7 @@ export default function RecruitCoreCompleted() {
               : '지원이 정상적으로 완료되었습니다. 이후 일정은 아래 안내를 확인해 주세요.'}
           </div>
 
-          <div className="space-y-2">
-            <p className="pl-2 typo-pc-s2 mobile:typo-m-s1 text-white">모집 일정</p>
-            <div className="rounded-xl bg-gray-100 px-4 py-3 text-white">
-              <div className="space-y-4 typo-pc-b2 mobile:space-y-3 mobile:typo-m-b3">
-                <div className="space-y-1">
-                  <Bullet>서류 지원 기간</Bullet>
-                  <p>2026. 2. 12.(목) - 2026. 3. 14.(토) 23:59</p>
-                </div>
-                <div className="space-y-1">
-                  <Bullet>서류 결과 발표</Bullet>
-                  <p>~ 2026. 3. 15.(일)</p>
-                </div>
-                <div className="space-y-1">
-                  <Bullet>면접 진행 기간</Bullet>
-                  <p>2026. 3. 16.(월) - 2026. 3. 20.(금)</p>
-                  <p className="typo-pc-c2 mobile:typo-m-c2 text-gray-700">
-                    ※ 지원자 및 면접관 일정에 따라 마감 전 면접이 가능할 수 있습니다.
-                  </p>
-                </div>
-                <div className="space-y-1">
-                  <Bullet>최종 결과 발표</Bullet>
-                  <p>~ 2026. 3. 21.(토)</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <p className="pl-2 typo-pc-s2 mobile:typo-m-s1 text-white">면접 안내</p>
-            <div className="rounded-xl bg-gray-100 px-4 py-3 text-white typo-pc-b2 mobile:typo-m-b3">
-              <Bullet>원칙적으로 대면 면접을 진행하며, 부득이한 경우 비대면으로 조정될 수 있습니다.</Bullet>
-              <div className="mt-2">
-                <Bullet>면접은 인하대학교 내부 장소에서 진행됩니다.</Bullet>
-              </div>
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <p className="pl-2 typo-pc-s2 mobile:typo-m-s1 text-white">활동 안내</p>
-            <div className="rounded-xl bg-gray-100 px-4 py-3 text-white typo-pc-b2 mobile:typo-m-b3">
-              <Bullet>운영진으로 활동 시, 매주 1회 정기 운영진 회의에 필수 참석해야 합니다.</Bullet>
-              <p className="mt-1 typo-pc-c2 mobile:typo-m-c2 text-gray-700">※ 일정은 3월 내로 공지 드립니다.</p>
-            </div>
-          </div>
+          <RecruitScheduleCard />
 
           <div className="flex justify-end pt-4">
             <Link href="/">

--- a/src/app/recruit/core/layout.tsx
+++ b/src/app/recruit/core/layout.tsx
@@ -1,15 +1,11 @@
 import type { Metadata } from 'next'
-import ApiCodeGuard from '@/components/auth/ApiCodeGuard'
+import RecruitCoreGate from '@/components/recruit/RecruitCoreGate'
 
 export const metadata: Metadata = {
   title: '운영진 모집',
-  description: 'GDGoC INHA 2026-1 운영진(CORE) 멤버를 모집합니다.'
+  description: 'GDGoC INHA 2026-2 운영진(CORE) 멤버를 모집합니다.'
 }
 
 export default function RecruitCoreLayout({ children }) {
-  return (
-    <ApiCodeGuard requiredRole="GUEST" nextOverride="/recruit/core">
-      {children}
-    </ApiCodeGuard>
-  )
+  return <RecruitCoreGate>{children}</RecruitCoreGate>
 }

--- a/src/app/recruit/core/page.tsx
+++ b/src/app/recruit/core/page.tsx
@@ -15,6 +15,7 @@ import {
   GdgInputField
 } from '@/components/ui/design-system'
 import { PrivacyPolicyNotice } from '@/components/ui/common/PrivacyPolicyNotice'
+import { RecruitScheduleCard } from '@/components/recruit/RecruitScheduleCard'
 import { normalizeMajorCode } from '@/constant/majorOptions'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
 import { usePhoneNumber } from '@/hooks/usePhoneNumber'
@@ -63,7 +64,6 @@ const TEAM_OPTIONS = [
   { id: 'TECH', label: 'TECH' },
   { id: 'PR_DESIGN', label: 'PR·DESIGN' }
 ] as const
-const CORE_RECRUIT_DEADLINE = '2026-03-14T23:59:59+09:00'
 
 const unwrapPrefill = (raw: unknown): PrefillPayload | null => {
   if (!raw || typeof raw !== 'object') return null
@@ -182,17 +182,6 @@ function TextareaField({
   )
 }
 
-function Bullet({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="flex items-start w-full">
-      <span className="w-5 shrink-0 text-center text-[18px] mobile:text-[16px] leading-none font-bold mt-[1px]">
-        •
-      </span>
-      <div className="typo-pc-b2 mobile:typo-m-b3 flex-1">{children}</div>
-    </div>
-  )
-}
-
 export default function RecruitCore() {
   const router = useRouter()
   const { apiClient } = useAuthenticatedApi()
@@ -205,7 +194,6 @@ export default function RecruitCore() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [scheduleChecked, setScheduleChecked] = useState(false)
   const [agreementChecked, setAgreementChecked] = useState(false)
-  const isRecruitClosed = Date.now() > new Date(CORE_RECRUIT_DEADLINE).getTime()
 
   const [formData, setFormData] = useState<RecruitFormData>({
     name: '',
@@ -246,19 +234,6 @@ export default function RecruitCore() {
   }, [currentStep, formData, scheduleChecked, agreementChecked])
 
   useEffect(() => {
-    if (!isRecruitClosed) {
-      return
-    }
-
-    alert('코어 지원 기간이 종료되었습니다.')
-    router.replace('/recruit/core/completed?status=closed')
-  }, [isRecruitClosed, router])
-
-  useEffect(() => {
-    if (isRecruitClosed) {
-      return
-    }
-
     let active = true
 
     const fetchPrefill = async () => {
@@ -295,7 +270,7 @@ export default function RecruitCore() {
     return () => {
       active = false
     }
-  }, [apiClient, isRecruitClosed, router])
+  }, [apiClient, router])
 
   const validateStep = (step: RecruitStep) => {
     const nextErrors: Record<string, boolean> = {}
@@ -427,12 +402,6 @@ export default function RecruitCore() {
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-
-    if (isRecruitClosed) {
-      alert('코어 지원 기간이 종료되었습니다.')
-      router.replace('/recruit/core/completed?status=closed')
-      return
-    }
 
     if (!validateStep(currentStep)) return
 
@@ -827,51 +796,9 @@ export default function RecruitCore() {
 
           {currentStep === 2 ? (
             <>
-              <div className="col-span-4 space-y-2">
-                <p className="pl-2 typo-pc-s2 mobile:typo-m-s1 text-white">모집 일정</p>
-                <div className="rounded-xl bg-gray-100 px-4 py-3 text-white">
-                  <div className="space-y-4 typo-pc-b2 mobile:space-y-3 mobile:typo-m-b3">
-                    <div className="space-y-1">
-                      <Bullet>서류 지원 기간</Bullet>
-                      <p>2026. 2. 12.(목) - 2026. 3. 14.(토) 23:59:59</p>
-                    </div>
-                    <div className="space-y-1">
-                      <Bullet>서류 결과 발표</Bullet>
-                      <p>~ 2026. 3. 15.(일)</p>
-                    </div>
-                    <div className="space-y-1">
-                      <Bullet>면접 진행 기간</Bullet>
-                      <p>2026. 3. 16.(월) - 2026. 3. 20.(금)</p>
-                      <p className="typo-c2 text-gray-700">
-                        ※ 지원자 및 면접관 일정에 따라 마감 전 면접이 가능할 수 있습니다.
-                      </p>
-                    </div>
-                    <div className="space-y-1">
-                      <Bullet>최종 결과 발표</Bullet>
-                      <p>~ 2026. 3. 21.(토)</p>
-                    </div>
-                  </div>
-                </div>
-              </div>
+              <div className="col-span-4 space-y-8 mobile:space-y-6">
+                <RecruitScheduleCard />
 
-              <div className="col-span-4 space-y-2">
-                <p className="pl-2 typo-pc-s2 mobile:typo-m-s1 text-white">면접 안내</p>
-                <div className="rounded-xl bg-gray-100 px-4 py-3 text-white typo-pc-b2 mobile:typo-m-b3">
-                  <Bullet>원칙적으로 대면 면접을 진행하며, 부득이한 경우 비대면으로 조정될 수 있습니다.</Bullet>
-                  <div className="mt-2">
-                    <Bullet>면접은 인하대학교 내부 장소에서 진행됩니다.</Bullet>
-                  </div>
-                </div>
-              </div>
-
-              <div className="col-span-4 space-y-4">
-                <div className="space-y-2">
-                  <p className="pl-2 typo-pc-s2 mobile:typo-m-s1 text-white">활동 안내</p>
-                  <div className="rounded-xl bg-gray-100 px-4 py-3 text-white typo-pc-b2 mobile:typo-m-b3">
-                    <Bullet>운영진으로 활동 시, 매주 1회 정기 운영진 회의에 필수 참석해야 합니다.</Bullet>
-                    <p className="mt-1 typo-c2 text-gray-700">※ 일정은 3월 내로 공지 드립니다.</p>
-                  </div>
-                </div>
                 <div className="flex items-center justify-end gap-2">
                   <span className="typo-pc-b3 mobile:typo-m-c1 text-red">*</span>
                   <p className="typo-pc-b3 mobile:typo-m-c1 text-white">전체 일정을 확인하였습니다.</p>

--- a/src/app/recruit/member/completed/page.tsx
+++ b/src/app/recruit/member/completed/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { GdgLogo } from '@/components/ui/design-system'
+import { MEMBER_SCHEDULE } from '@/constant/recruitSchedule'
 import { cn } from '@/utils/cn'
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
@@ -120,7 +121,7 @@ export default function RecruitSubmit() {
             <Card className="flex-col items-start gap-2">
               <Bullet>
                 <span className="font-bold mr-2">집중 모집 기간</span>
-                <span>2/12 ~ 3/15</span>
+                <span>{MEMBER_SCHEDULE.intensive}</span>
               </Bullet>
             </Card>
 

--- a/src/app/recruit/member/layout.tsx
+++ b/src/app/recruit/member/layout.tsx
@@ -3,7 +3,7 @@ import { type Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: '멤버 모집',
-  description: 'GDGoC INHA 2026-1 신입 멤버를 모집합니다.'
+  description: 'GDGoC INHA 2026-2 신입 멤버를 모집합니다.'
 }
 
 export default function RecruitMemberLayout({ children }: { children: ReactNode }) {

--- a/src/app/recruit/page.tsx
+++ b/src/app/recruit/page.tsx
@@ -1,5 +1,58 @@
-import { redirect } from 'next/navigation'
+'use client'
 
-export default function RecruitRedirect() {
-  redirect('/recruit/member')
+import { GdgLogo } from '@/components/ui/design-system'
+import { RecruitTypeCard } from '@/components/recruit/RecruitTypeCard'
+import { useRecruitCorePeriod } from '@/hooks/useRecruitCorePeriod'
+import { CORE_SCHEDULE, MEMBER_SCHEDULE, formatKoreanDate } from '@/constant/recruitSchedule'
+
+export default function RecruitSelect() {
+  const { period, failed } = useRecruitCorePeriod()
+
+  // 조회에 실패하면 열어둔다. 제출은 서버가 최종 판정하므로 안전하다.
+  const coreUnknown = failed || !period
+  const coreOpen = coreUnknown || period.status === 'OPEN'
+  const coreStatusLabel = coreUnknown
+    ? '모집중'
+    : period.status === 'OPEN'
+      ? '모집중'
+      : period.status === 'BEFORE_OPEN'
+        ? `${formatKoreanDate(period.openAt)} 오픈`
+        : '모집 마감'
+  const corePeriodText = period
+    ? `${formatKoreanDate(period.openAt)} - ${formatKoreanDate(period.closeAt)}`
+    : CORE_SCHEDULE.application
+
+  return (
+    <main className="min-h-screen bg-black overflow-x-hidden">
+      <div className="relative z-10 pt-18 pb-32 mobile:pt-12 mobile:pb-24 layout-grid layout-grid--narrow-screen layout-grid--4 gap-y-10">
+        <div className="col-span-4 flex flex-col gap-3 mobile:gap-2">
+          <div className="flex items-center gap-3 mobile:gap-2">
+            <GdgLogo mode="auto" />
+            <h1 className="typo-pc-h3 text-white mobile:typo-m-h2">GDGoC INHA 2026-2</h1>
+          </div>
+          <p className="typo-pc-b2 text-gray-700 mobile:typo-m-b3">지원 종류를 선택해 주세요.</p>
+        </div>
+
+        <div className="col-span-4 grid grid-cols-2 gap-5 mobile:grid-cols-1 mobile:gap-4">
+          <RecruitTypeCard
+            title="Core"
+            subtitle="운영진"
+            period={corePeriodText}
+            href="/recruit/core"
+            statusLabel={coreStatusLabel}
+            isOpen={coreOpen}
+          />
+          {/* 부원 모집은 서버에 기간 차단 로직이 없어 상시 지원 가능하다. 항상 열어둔다. */}
+          <RecruitTypeCard
+            title="Member"
+            subtitle="부원"
+            period={MEMBER_SCHEDULE.intensive}
+            href="/recruit/member"
+            statusLabel="모집중"
+            isOpen
+          />
+        </div>
+      </div>
+    </main>
+  )
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -8,6 +8,8 @@ export default function robots() {
                 userAgent: '*',
                 allow: [
                     '/',
+                    '/recruit',
+                    '/recruit/core',
                     '/images/',
                     '/fonts/',
                     '/static/',

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -12,6 +12,18 @@ export default function sitemap() {
             priority: 1,
         },
         {
+            url: `${baseUrl}/recruit`,
+            lastModified: currentDate,
+            changeFrequency: 'weekly',
+            priority: 0.9,
+        },
+        {
+            url: `${baseUrl}/recruit/core`,
+            lastModified: currentDate,
+            changeFrequency: 'weekly',
+            priority: 0.8,
+        },
+        {
             url: `${baseUrl}/recruit/member`,
             lastModified: currentDate,
             changeFrequency: 'weekly',

--- a/src/components/landing/OnboardingLanding.tsx
+++ b/src/components/landing/OnboardingLanding.tsx
@@ -517,7 +517,7 @@ function RecruitButton({ className }: { className?: string }) {
         'h-[52px] max-w-[550px] border-red bg-red typo-pc-s3 mobile:h-12 mobile:max-w-[166px] mobile:px-8 mobile:typo-m-s3',
         className
       )}
-      onClick={() => router.push('/recruit/member')}
+      onClick={() => router.push('/recruit')}
     >
       지원하기
     </GdgButton>

--- a/src/components/recruit/RecruitCoreGate.tsx
+++ b/src/components/recruit/RecruitCoreGate.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import Link from 'next/link'
+import ApiCodeGuard from '@/components/auth/ApiCodeGuard'
+import { GdgButton, GdgLogo } from '@/components/ui/design-system'
+import Loader from '@/components/ui/common/Loader'
+import { RecruitScheduleCard } from '@/components/recruit/RecruitScheduleCard'
+import { useRecruitCorePeriod } from '@/hooks/useRecruitCorePeriod'
+import { formatKoreanDate } from '@/constant/recruitSchedule'
+
+function NoticeScreen({
+  title,
+  message,
+  openAt,
+  closeAt
+}: {
+  title: string
+  message: string
+  openAt: string
+  closeAt: string
+}) {
+  return (
+    <main className="min-h-screen bg-black overflow-x-hidden">
+      <div className="relative z-10 pt-18 pb-32 mobile:pt-12 mobile:pb-24 layout-grid layout-grid--narrow-screen layout-grid--4 gap-y-10">
+        <div className="col-span-4 flex items-center gap-3 mobile:gap-2">
+          <GdgLogo mode="auto" />
+          <h1 className="typo-pc-h3 text-white mobile:typo-m-h2">{title}</h1>
+        </div>
+
+        <div className="col-span-4 flex flex-col gap-10 w-full">
+          <div className="rounded-xl bg-gray-100 px-4 py-3 text-white typo-pc-b2 mobile:typo-m-b3">
+            {message}
+          </div>
+
+          <RecruitScheduleCard applicationPeriod={{ openAt, closeAt }} />
+
+          <div className="flex justify-end pt-4">
+            <Link href="/">
+              <GdgButton variant="active" size="small">
+                홈으로 이동
+              </GdgButton>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}
+
+/**
+ * 모집 기간을 로그인보다 **먼저** 판정한다.
+ *
+ * 모집이 시작되지 않았는데 로그인부터 요구하는 건 어색하고, 비로그인 사용자도
+ * 일정은 볼 수 있어야 한다. 그래서 ApiCodeGuard 를 이 안쪽에 둔다.
+ */
+export default function RecruitCoreGate({ children }: { children: React.ReactNode }) {
+  const { period, loading, failed } = useRecruitCorePeriod()
+
+  if (loading) return <Loader />
+
+  // 조회에 실패하면 폼을 연다. 제출은 서버가 최종 판정하므로 안전하고,
+  // 반대로 닫으면 API 일시 장애가 곧 지원 불가가 된다.
+  if (failed || !period) {
+    return (
+      <ApiCodeGuard requiredRole="GUEST" nextOverride="/recruit/core">
+        {children}
+      </ApiCodeGuard>
+    )
+  }
+
+  if (period.status === 'BEFORE_OPEN') {
+    return (
+      <NoticeScreen
+        title="Core Member 모집 예정"
+        message={`${formatKoreanDate(period.openAt)}부터 지원서를 받습니다. 아래 일정을 확인해 주세요.`}
+        openAt={period.openAt}
+        closeAt={period.closeAt}
+      />
+    )
+  }
+
+  if (period.status === 'CLOSED') {
+    return (
+      <NoticeScreen
+        title="Core Member 지원 마감"
+        message="코어 지원 기간이 종료되어 더 이상 지원서를 제출할 수 없습니다."
+        openAt={period.openAt}
+        closeAt={period.closeAt}
+      />
+    )
+  }
+
+  return (
+    <ApiCodeGuard requiredRole="GUEST" nextOverride="/recruit/core">
+      {children}
+    </ApiCodeGuard>
+  )
+}

--- a/src/components/recruit/RecruitScheduleCard.tsx
+++ b/src/components/recruit/RecruitScheduleCard.tsx
@@ -1,0 +1,60 @@
+import { Bullet } from '@/components/ui/common/Bullet'
+import { CORE_SCHEDULE, formatKoreanDate } from '@/constant/recruitSchedule'
+
+type Props = {
+  /** 서버가 내려준 실제 모집 기간. 있으면 이 값으로 렌더해 게이팅과 어긋나지 않게 한다. */
+  applicationPeriod?: { openAt: string; closeAt: string }
+}
+
+export function RecruitScheduleCard({ applicationPeriod }: Props) {
+  const applicationText = applicationPeriod
+    ? `${formatKoreanDate(applicationPeriod.openAt)} - ${formatKoreanDate(applicationPeriod.closeAt)} 23:59:59`
+    : CORE_SCHEDULE.application
+
+  return (
+    <>
+      <div className="space-y-2">
+        <p className="pl-2 typo-pc-s2 mobile:typo-m-s1 text-white">모집 일정</p>
+        <div className="rounded-xl bg-gray-100 px-4 py-3 text-white">
+          <div className="space-y-4 typo-pc-b2 mobile:space-y-3 mobile:typo-m-b3">
+            <div className="space-y-1">
+              <Bullet>서류 지원 기간</Bullet>
+              <p>{applicationText}</p>
+            </div>
+            <div className="space-y-1">
+              <Bullet>서류 결과 발표</Bullet>
+              <p>{CORE_SCHEDULE.documentResult}</p>
+            </div>
+            <div className="space-y-1">
+              <Bullet>면접 진행 기간</Bullet>
+              <p>{CORE_SCHEDULE.interview}</p>
+              <p className="typo-pc-c2 mobile:typo-m-c2 text-gray-700">{CORE_SCHEDULE.interviewNote}</p>
+            </div>
+            <div className="space-y-1">
+              <Bullet>최종 결과 발표</Bullet>
+              <p>{CORE_SCHEDULE.finalResult}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="pl-2 typo-pc-s2 mobile:typo-m-s1 text-white">면접 안내</p>
+        <div className="rounded-xl bg-gray-100 px-4 py-3 text-white typo-pc-b2 mobile:typo-m-b3">
+          <Bullet>원칙적으로 대면 면접을 진행하며, 부득이한 경우 비대면으로 조정될 수 있습니다.</Bullet>
+          <div className="mt-2">
+            <Bullet>면접은 인하대학교 내부 장소에서 진행됩니다.</Bullet>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="pl-2 typo-pc-s2 mobile:typo-m-s1 text-white">활동 안내</p>
+        <div className="rounded-xl bg-gray-100 px-4 py-3 text-white typo-pc-b2 mobile:typo-m-b3">
+          <Bullet>운영진으로 활동 시, 매주 1회 정기 운영진 회의에 필수 참석해야 합니다.</Bullet>
+          <p className="mt-1 typo-pc-c2 mobile:typo-m-c2 text-gray-700">{CORE_SCHEDULE.meetingNote}</p>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/recruit/RecruitTypeCard.tsx
+++ b/src/components/recruit/RecruitTypeCard.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { GdgButton } from '@/components/ui/design-system'
+import { cn } from '@/utils/cn'
+
+type Props = {
+  title: string
+  subtitle: string
+  period: string
+  href: string
+  statusLabel: string
+  isOpen: boolean
+}
+
+export function RecruitTypeCard({ title, subtitle, period, href, statusLabel, isOpen }: Props) {
+  const router = useRouter()
+
+  return (
+    <div className="flex flex-col gap-6 rounded-xl bg-gray-100 px-6 py-6 mobile:gap-4 mobile:px-4 mobile:py-5">
+      <div className="flex items-center gap-2">
+        <span
+          className={cn('inline-block h-2 w-2 rounded-full', isOpen ? 'bg-red' : 'bg-gray-700')}
+          aria-hidden
+        />
+        <span className={cn('typo-pc-c1 mobile:typo-m-c2', isOpen ? 'text-red' : 'text-gray-700')}>
+          {statusLabel}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <p className="typo-pc-h3 text-white mobile:typo-m-h3">{title}</p>
+        <p className="typo-pc-b3 text-gray-700 mobile:typo-m-c1">{subtitle}</p>
+      </div>
+
+      <p className="typo-pc-b2 text-white mobile:typo-m-b3">{period}</p>
+
+      <GdgButton
+        variant={isOpen ? 'active' : 'disabled'}
+        size="small"
+        fullWidth
+        disabled={!isOpen}
+        onClick={() => router.push(href)}
+      >
+        지원하기
+      </GdgButton>
+    </div>
+  )
+}

--- a/src/components/ui/common/Bullet.tsx
+++ b/src/components/ui/common/Bullet.tsx
@@ -1,0 +1,10 @@
+export function Bullet({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-start w-full">
+      <span className="w-5 shrink-0 text-center text-[18px] mobile:text-[16px] leading-none font-bold mt-[1px]">
+        •
+      </span>
+      <div className="typo-pc-b2 mobile:typo-m-b3 flex-1">{children}</div>
+    </div>
+  )
+}

--- a/src/constant/recruitSchedule.ts
+++ b/src/constant/recruitSchedule.ts
@@ -1,0 +1,31 @@
+/**
+ * 모집 일정 표시용 텍스트.
+ *
+ * 실제 지원 가능 여부(게이팅)는 서버가 판정한다 — `app.recruit.core.open-at` / `close-at`.
+ * 여기 값은 화면에 보이는 문구일 뿐이다. 2차 모집 때 서버 환경변수만 바꾸면 게이팅은
+ * 열리지만 아래 문구는 그대로이므로, **일정이 바뀌면 서버 설정과 이 파일을 함께 고친다.**
+ *
+ * 단, 서류 지원 기간은 RecruitScheduleCard 가 서버 응답으로 렌더할 수 있다.
+ * 그 경우 CORE_SCHEDULE.application 은 서버 응답을 못 받았을 때의 대체값으로만 쓰인다.
+ */
+
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'] as const
+
+/** ISO 문자열을 KST 기준 `2026. 8. 10.(월)` 로 만든다. 보는 사람의 시간대와 무관하다. */
+export function formatKoreanDate(iso: string): string {
+  const kst = new Date(new Date(iso).getTime() + 9 * 60 * 60 * 1000)
+  return `${kst.getUTCFullYear()}. ${kst.getUTCMonth() + 1}. ${kst.getUTCDate()}.(${WEEKDAYS[kst.getUTCDay()]})`
+}
+
+export const CORE_SCHEDULE = {
+  application: '2026. 8. 10.(월) - 2026. 8. 30.(일) 23:59:59',
+  documentResult: '~ 2026. 8. 31.(월)',
+  interview: '2026. 9. 1.(화) - 2026. 9. 5.(토)',
+  interviewNote: '※ 지원자 및 면접관 일정에 따라 마감 전 면접이 가능할 수 있습니다.',
+  finalResult: '~ 2026. 9. 6.(일)',
+  meetingNote: '※ 일정은 9월 내로 공지 드립니다.'
+} as const
+
+export const MEMBER_SCHEDULE = {
+  intensive: '8/17 ~ 9/9'
+} as const

--- a/src/hooks/useRecruitCorePeriod.ts
+++ b/src/hooks/useRecruitCorePeriod.ts
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export type RecruitCorePeriodStatus = 'BEFORE_OPEN' | 'OPEN' | 'CLOSED'
+
+export type RecruitCorePeriod = {
+  session: string
+  openAt: string
+  closeAt: string
+  status: RecruitCorePeriodStatus
+}
+
+/**
+ * 코어 모집 기간을 서버에서 가져온다.
+ *
+ * 인증이 필요 없는 공개 GET 이므로 authorizedClient 를 쓰지 않는다.
+ * 실패해도 화면을 막지 않는다 — 호출부가 `failed` 를 보고 열어두도록 판단한다.
+ */
+export function useRecruitCorePeriod() {
+  const [period, setPeriod] = useState<RecruitCorePeriod | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    let active = true
+
+    const fetchPeriod = async () => {
+      try {
+        const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_API_URL}/recruit/core/period`)
+        if (!response.ok) throw new Error(`status ${response.status}`)
+
+        const body = await response.json()
+        if (!active) return
+
+        // 응답이 { code, message, data } 로 감싸여 올 수도, 평평하게 올 수도 있다.
+        const payload = body?.data ?? body
+        if (!payload?.status) throw new Error('status 없음')
+
+        setPeriod(payload as RecruitCorePeriod)
+      } catch (error) {
+        if (!active) return
+        console.error('[코어 리크루팅] 모집 기간을 불러오지 못했습니다.', error)
+        setFailed(true)
+      } finally {
+        if (active) setLoading(false)
+      }
+    }
+
+    void fetchPeriod()
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  return { period, loading, failed }
+}


### PR DESCRIPTION
> **스택 PR** — base 가 `chore/sync-develop-from-master`(#336) 다. #336 이 머지되면 base 가 `develop` 으로 자동 전환된다.
>
> **서버 PR 을 먼저 배포해야 한다** — GDGoCINHA/24-2_GDGoC_Server#334. 없는 엔드포인트를 부르면 게이트가 `failed` 로 떨어져 폼이 그냥 열린다(안전하지만 검증이 안 된다).

## 배경

2026-2 코어 모집이 **8/10 에 시작**하는데 웹에 세 가지 문제가 있었다.

1. **진입 경로가 없다.** `/recruit/core` 링크는 부원 지원 완료 페이지 한 곳뿐. 랜딩 CTA 는 전부 `/recruit/member` 로 간다. **8/10~8/16 은 코어만 모집하는데** 지원자가 갈 곳이 없었다.
2. **웹이 자체 마감일을 들고 있었다.** `CORE_RECRUIT_DEADLINE = '2026-03-14...'` 로 진입 즉시 마감 페이지로 리다이렉트. 서버와 어긋날 수 있는 구조다.
3. **일정 카드가 두 파일에 통째로 복붙**돼 있었고 `Bullet` 도 각각 정의돼 있었다.

## 변경

**판정을 서버로 (`RecruitCoreGate`)**

기간 확인을 `ApiCodeGuard` **앞에** 둔다. 모집이 시작되지 않았는데 로그인부터 요구하는 건 어색하고, 비로그인 사용자도 일정은 볼 수 있어야 한다.

```
layout.tsx (서버 컴포넌트, metadata 유지)
  └ RecruitCoreGate (클라이언트)
      ├ BEFORE_OPEN → "모집 예정" 안내   (로그인 불필요)
      ├ CLOSED      → "지원 마감" 안내   (로그인 불필요)
      └ OPEN        → ApiCodeGuard → 지원 폼
```

**조회 실패 시 폼을 연다.** 제출은 서버가 최종 판정하므로 안전하고, 닫아버리면 API 일시 장애가 곧 지원 불가가 된다.

페이지에 흩어져 있던 자체 판정 **4곳**(상수, `isRecruitClosed`, 진입 리다이렉트 `useEffect`, 제출 시 재확인)을 모두 걷어냈다.

**`/recruit` 갈림길 페이지**

`redirect('/recruit/member')` 였던 것을 선택 화면으로. 코어 카드 상태는 서버 응답을 따르고, 부원 카드는 서버에 차단 로직이 없어 실제로 상시 지원 가능하므로 항상 열어둔다. 랜딩 `RecruitButton` 을 `/recruit` 으로 돌렸다.

**중복 제거**

`RecruitScheduleCard` 로 일정·면접·활동 카드 3개를 합치고, `Bullet` 을 `components/ui/common/` 으로 옮겼다. 일정 텍스트는 `constant/recruitSchedule.ts` 한 곳으로.

서류 지원 기간은 서버가 내려준 값으로 렌더한다 — 게이팅과 화면 문구가 어긋나지 않게.

**2026-2 일정 반영**

| 항목 | 값 |
|---|---|
| 코어 서류 지원 | 8/10(월) ~ 8/30(일) 23:59:59 |
| 코어 서류 결과 | ~ 8/31(월) |
| 코어 면접 | 9/1(화) ~ 9/5(토) |
| 코어 최종 결과 | ~ 9/6(일) |
| 부원 집중 모집 | 8/17 ~ 9/9 |

`sitemap.ts`·`robots.ts` 에 `/recruit`, `/recruit/core` 를 추가했다(색인 대상에서 빠져 있었다).

## 알아둘 것

- **캡션 클래스를 통일했다.** `core/page.tsx` 는 `typo-c2`, `completed/page.tsx` 는 `typo-pc-c2 mobile:typo-m-c2` 를 쓰고 있었다. 반응형 쌍을 갖춘 쪽으로 맞춰서 `core/page.tsx` 캡션이 모바일에서 미세하게 바뀐다. 의도된 변경이다.
- **일정 안내 문구는 여전히 웹 상수다.** 서버 환경변수만 바꾸면 게이팅은 열리지만 면접·발표 날짜 문구는 그대로다. 2차 모집 때는 `constant/recruitSchedule.ts` 도 함께 고쳐야 한다 (파일 상단에 명시해 두었다).

## 검증

```
yarn build  →  exit 0 (52 pages)
```

생성물 직접 확인:
- `out/sitemap.xml` → `/recruit`, `/recruit/core` 포함
- `out/robots.txt` → `Allow: /recruit`, `Allow: /recruit/core`

⚠️ 이 리포에는 PR CI 가 없다. 로컬 빌드가 유일한 게이트다.

## 머지 후 수동 확인

| 확인 | 기대 (8/10 이전 기준) |
|---|---|
| `/recruit` | 카드 2개, 코어는 "8. 10.(월) 오픈" 비활성 |
| `/recruit/core` 비로그인 직접 진입 | **로그인 요구 없이** "모집 예정" 안내 |
| 랜딩 "지원하기" | `/recruit` 로 이동 |
| `/recruit/member` | 정상 (변경 없음) |
| `/recruit/member/completed` | 집중 모집 기간 `8/17 ~ 9/9` |

8/10 이전에 폼까지 검증하려면 dev 서버의 `RECRUIT_CORE_OPEN_AT` 를 과거 날짜로 잠시 바꾸면 된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LLvZ5krbJny7G7Yrr5syj