### PR TITLE
fix: 모집 기간 표기 통일 및 지원 카드 정렬

### DIFF
--- a/src/app/recruit/member/completed/page.tsx
+++ b/src/app/recruit/member/completed/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { GdgLogo } from '@/components/ui/design-system'
-import { MEMBER_SCHEDULE } from '@/constant/recruitSchedule'
+import { MEMBER_SCHEDULE, formatKoreanPeriod } from '@/constant/recruitSchedule'
 import { cn } from '@/utils/cn'
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
@@ -121,7 +121,7 @@ export default function RecruitSubmit() {
             <Card className="flex-col items-start gap-2">
               <Bullet>
                 <span className="font-bold mr-2">집중 모집 기간</span>
-                <span>{MEMBER_SCHEDULE.intensive}</span>
+                <span>{formatKoreanPeriod(MEMBER_SCHEDULE.openAt, MEMBER_SCHEDULE.closeAt)}</span>
               </Bullet>
             </Card>
 

--- a/src/app/recruit/page.tsx
+++ b/src/app/recruit/page.tsx
@@ -3,7 +3,12 @@
 import { GdgLogo } from '@/components/ui/design-system'
 import { RecruitTypeCard } from '@/components/recruit/RecruitTypeCard'
 import { useRecruitCorePeriod } from '@/hooks/useRecruitCorePeriod'
-import { CORE_SCHEDULE, MEMBER_SCHEDULE, formatKoreanDate } from '@/constant/recruitSchedule'
+import {
+  CORE_SCHEDULE,
+  MEMBER_SCHEDULE,
+  formatKoreanDateShort,
+  formatKoreanPeriodShort
+} from '@/constant/recruitSchedule'
 
 export default function RecruitSelect() {
   const { period, failed } = useRecruitCorePeriod()
@@ -16,11 +21,11 @@ export default function RecruitSelect() {
     : period.status === 'OPEN'
       ? '모집중'
       : period.status === 'BEFORE_OPEN'
-        ? `${formatKoreanDate(period.openAt)} 오픈`
+        ? `${formatKoreanDateShort(period.openAt)} 오픈`
         : '모집 마감'
   const corePeriodText = period
-    ? `${formatKoreanDate(period.openAt)} - ${formatKoreanDate(period.closeAt)}`
-    : CORE_SCHEDULE.application
+    ? formatKoreanPeriodShort(period.openAt, period.closeAt)
+    : formatKoreanPeriodShort(CORE_SCHEDULE.fallbackOpenAt, CORE_SCHEDULE.fallbackCloseAt)
 
   return (
     <main className="min-h-screen bg-black overflow-x-hidden">
@@ -33,7 +38,7 @@ export default function RecruitSelect() {
           <p className="typo-pc-b2 text-gray-700 mobile:typo-m-b3">지원 종류를 선택해 주세요.</p>
         </div>
 
-        <div className="col-span-4 grid grid-cols-2 gap-5 mobile:grid-cols-1 mobile:gap-4">
+        <div className="col-span-4 grid grid-cols-2 items-stretch gap-5 mobile:grid-cols-1 mobile:gap-4">
           <RecruitTypeCard
             title="Core"
             subtitle="운영진"
@@ -46,7 +51,7 @@ export default function RecruitSelect() {
           <RecruitTypeCard
             title="Member"
             subtitle="부원"
-            period={MEMBER_SCHEDULE.intensive}
+            period={formatKoreanPeriodShort(MEMBER_SCHEDULE.openAt, MEMBER_SCHEDULE.closeAt)}
             href="/recruit/member"
             statusLabel="모집중"
             isOpen

--- a/src/components/recruit/RecruitScheduleCard.tsx
+++ b/src/components/recruit/RecruitScheduleCard.tsx
@@ -1,5 +1,5 @@
 import { Bullet } from '@/components/ui/common/Bullet'
-import { CORE_SCHEDULE, formatKoreanDate } from '@/constant/recruitSchedule'
+import { CORE_SCHEDULE, formatKoreanPeriod } from '@/constant/recruitSchedule'
 
 type Props = {
   /** 서버가 내려준 실제 모집 기간. 있으면 이 값으로 렌더해 게이팅과 어긋나지 않게 한다. */
@@ -7,9 +7,11 @@ type Props = {
 }
 
 export function RecruitScheduleCard({ applicationPeriod }: Props) {
-  const applicationText = applicationPeriod
-    ? `${formatKoreanDate(applicationPeriod.openAt)} - ${formatKoreanDate(applicationPeriod.closeAt)} 23:59:59`
-    : CORE_SCHEDULE.application
+  const period = applicationPeriod ?? {
+    openAt: CORE_SCHEDULE.fallbackOpenAt,
+    closeAt: CORE_SCHEDULE.fallbackCloseAt
+  }
+  const applicationText = `${formatKoreanPeriod(period.openAt, period.closeAt)} 23:59:59`
 
   return (
     <>

--- a/src/components/recruit/RecruitTypeCard.tsx
+++ b/src/components/recruit/RecruitTypeCard.tsx
@@ -17,7 +17,8 @@ export function RecruitTypeCard({ title, subtitle, period, href, statusLabel, is
   const router = useRouter()
 
   return (
-    <div className="flex flex-col gap-6 rounded-xl bg-gray-100 px-6 py-6 mobile:gap-4 mobile:px-4 mobile:py-5">
+    // h-full + 버튼 mt-auto: 두 카드의 내용 길이가 달라도 높이와 버튼 위치가 맞는다.
+    <div className="flex h-full flex-col gap-6 rounded-xl bg-gray-100 px-6 py-6 mobile:gap-4 mobile:px-4 mobile:py-5">
       <div className="flex items-center gap-2">
         <span
           className={cn('inline-block h-2 w-2 rounded-full', isOpen ? 'bg-red' : 'bg-gray-700')}
@@ -36,6 +37,7 @@ export function RecruitTypeCard({ title, subtitle, period, href, statusLabel, is
       <p className="typo-pc-b2 text-white mobile:typo-m-b3">{period}</p>
 
       <GdgButton
+        className="mt-auto"
         variant={isOpen ? 'active' : 'disabled'}
         size="small"
         fullWidth

--- a/src/constant/recruitSchedule.ts
+++ b/src/constant/recruitSchedule.ts
@@ -1,24 +1,47 @@
 /**
  * 모집 일정 표시용 텍스트.
  *
- * 실제 지원 가능 여부(게이팅)는 서버가 판정한다 — `app.recruit.core.open-at` / `close-at`.
+ * 코어의 실제 지원 가능 여부(게이팅)는 서버가 판정한다 — `app.recruit.core.open-at` / `close-at`.
  * 여기 값은 화면에 보이는 문구일 뿐이다. 2차 모집 때 서버 환경변수만 바꾸면 게이팅은
  * 열리지만 아래 문구는 그대로이므로, **일정이 바뀌면 서버 설정과 이 파일을 함께 고친다.**
  *
- * 단, 서류 지원 기간은 RecruitScheduleCard 가 서버 응답으로 렌더할 수 있다.
- * 그 경우 CORE_SCHEDULE.application 은 서버 응답을 못 받았을 때의 대체값으로만 쓰인다.
+ * 날짜는 전부 ISO 문자열로 두고 아래 포맷터를 거친다. 코어는 서버가 준 타임스탬프를,
+ * 부원은 이 파일의 상수를 쓰는데, 각자 따로 문자열을 들고 있으면 포맷이 갈린다.
  */
 
 const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'] as const
 
-/** ISO 문자열을 KST 기준 `2026. 8. 10.(월)` 로 만든다. 보는 사람의 시간대와 무관하다. */
+/** ISO 문자열을 KST 기준으로 해석한다. 보는 사람의 시간대와 무관하다. */
+function toKst(iso: string): Date {
+  return new Date(new Date(iso).getTime() + 9 * 60 * 60 * 1000)
+}
+
+/** `2026. 8. 10.(월)` — 상세 일정 안내용. */
 export function formatKoreanDate(iso: string): string {
-  const kst = new Date(new Date(iso).getTime() + 9 * 60 * 60 * 1000)
-  return `${kst.getUTCFullYear()}. ${kst.getUTCMonth() + 1}. ${kst.getUTCDate()}.(${WEEKDAYS[kst.getUTCDay()]})`
+  const d = toKst(iso)
+  return `${d.getUTCFullYear()}. ${d.getUTCMonth() + 1}. ${d.getUTCDate()}.(${WEEKDAYS[d.getUTCDay()]})`
+}
+
+/** `8. 10.(월)` — 연도를 뺀 축약형. 카드처럼 폭이 좁은 곳에 쓴다. */
+export function formatKoreanDateShort(iso: string): string {
+  const d = toKst(iso)
+  return `${d.getUTCMonth() + 1}. ${d.getUTCDate()}.(${WEEKDAYS[d.getUTCDay()]})`
+}
+
+/** `2026. 8. 10.(월) - 2026. 8. 30.(일)` */
+export function formatKoreanPeriod(openAt: string, closeAt: string): string {
+  return `${formatKoreanDate(openAt)} - ${formatKoreanDate(closeAt)}`
+}
+
+/** `8. 10.(월) ~ 8. 30.(일)` */
+export function formatKoreanPeriodShort(openAt: string, closeAt: string): string {
+  return `${formatKoreanDateShort(openAt)} ~ ${formatKoreanDateShort(closeAt)}`
 }
 
 export const CORE_SCHEDULE = {
-  application: '2026. 8. 10.(월) - 2026. 8. 30.(일) 23:59:59',
+  /** 서버 응답을 못 받았을 때만 쓰는 대체값. 서버 설정(app.recruit.core.*)과 함께 고친다. */
+  fallbackOpenAt: '2026-08-10T00:00:00+09:00',
+  fallbackCloseAt: '2026-08-30T23:59:59+09:00',
   documentResult: '~ 2026. 8. 31.(월)',
   interview: '2026. 9. 1.(화) - 2026. 9. 5.(토)',
   interviewNote: '※ 지원자 및 면접관 일정에 따라 마감 전 면접이 가능할 수 있습니다.',
@@ -27,5 +50,7 @@ export const CORE_SCHEDULE = {
 } as const
 
 export const MEMBER_SCHEDULE = {
-  intensive: '8/17 ~ 9/9'
+  /** 집중 모집 기간. 이후 상시 모집으로 전환되며, 서버에 차단 로직은 없다. */
+  openAt: '2026-08-17T00:00:00+09:00',
+  closeAt: '2026-09-09T23:59:59+09:00'
 } as const


### PR DESCRIPTION
#337 후속. 배포된 화면을 보고 발견한 두 가지를 고친다.

## 1. 두 카드의 기간 표기 형식이 달랐다

| | 이전 |
|---|---|
| Core | `2026. 8. 10.(월) - 2026. 8. 30.(일)` |
| Member | `8/17 ~ 9/9` |

Core 는 서버 타임스탬프를 `formatKoreanDate` 로 포맷하고, Member 는 기존 완료 페이지에 있던 문자열을 그대로 가져다 쓴 탓이다.

**출처를 통일했다.** `MEMBER_SCHEDULE` 도 ISO 날짜로 바꿔 모든 날짜가 같은 포맷터를 거친다. 손으로 쓴 날짜 문자열(`CORE_SCHEDULE.application`, `MEMBER_SCHEDULE.intensive`)은 없앴고, 서버 응답을 못 받았을 때의 대체값도 ISO(`fallbackOpenAt`/`fallbackCloseAt`)로 두어 같은 경로를 탄다. 이제 한쪽만 형식이 어긋날 수 없다.

## 2. 카드 높이가 안 맞았다

전체 포맷이 카드 폭에 비해 길어 두 줄로 접혔고, `(일)` 이 혼자 내려가면서 Core 카드만 높아져 버튼이 어긋났다.

포맷터를 둘로 나눠 **카드에는 연도를 뺀 축약형**을 쓴다. 상세 일정 안내(`/recruit/core`)는 연도 포함 전체형 그대로다.

정렬은 `h-full` + 버튼 `mt-auto` + 그리드 `items-stretch` 로 잡았다.

## 결과

| 위치 | 이후 |
|---|---|
| `/recruit` Core 카드 | `8. 10.(월) ~ 8. 30.(일)` |
| `/recruit` Member 카드 | `8. 17.(월) ~ 9. 9.(수)` |
| `/recruit` Core 상태 | `8. 10.(월) 오픈` |
| `/recruit/core` 상세 | `2026. 8. 10.(월) - 2026. 8. 30.(일) 23:59:59` (변화 없음) |
| `/recruit/member/completed` | `2026. 8. 17.(월) - 2026. 9. 9.(수)` |

## 검증

```
yarn build  →  exit 0
```

옛 심볼(`CORE_SCHEDULE.application`, `MEMBER_SCHEDULE.intensive`) 잔여 참조 없음을 grep 으로 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LLvZ5krbJny7G7Yrr5syj