### PR TITLE
fix: 게시판 진입 경로·공지 접근 제어·모바일 레이아웃 수정

### DIFF
--- a/src/app/board/events/detail/page.tsx
+++ b/src/app/board/events/detail/page.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { AttachmentList } from '@/components/board/AttachmentList'
 import { GdgSiteHeader } from '@/components/ui/design-system'
+import { BOARD_MENUS } from '@/components/board/boardMenus'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
 import { deleteEvent, fetchEventDetail } from '@/services/board/boardClient'
@@ -115,7 +116,7 @@ export default function EventBoardDetailPage() {
   return (
     <main className="min-h-screen bg-black text-white">
       <GdgSiteHeader
-        menus={[{ label: '게시판', url: '/board/events/' }]}
+        menus={BOARD_MENUS}
         actionMenu={{
           label: user ? '내 정보' : '로그인',
           url: user ? '/profile/' : '/login?next=%2Fboard%2Fevents%2F'

--- a/src/app/board/events/detail/page.tsx
+++ b/src/app/board/events/detail/page.tsx
@@ -88,14 +88,14 @@ export default function EventBoardDetailPage() {
   const canManage = hasAtLeast(user?.userRole, 'CORE')
 
   if (loading) {
-    return <p className="py-16 text-center text-white typo-pc-b2">불러오는 중...</p>
+    return <p className="py-16 text-center text-white typo-pc-b2 mobile:typo-m-b2">불러오는 중...</p>
   }
 
   if (notFound) {
     return (
       <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
-        <p className="typo-pc-b2">삭제되었거나 존재하지 않는 글입니다.</p>
-        <Link href="/board/events/" className="mt-4 inline-block underline typo-pc-b3">
+        <p className="typo-pc-b2 mobile:typo-m-b2">삭제되었거나 존재하지 않는 글입니다.</p>
+        <Link href="/board/events/" className="mt-4 inline-block underline typo-pc-b3 mobile:typo-m-b3">
           목록으로
         </Link>
       </main>
@@ -105,8 +105,8 @@ export default function EventBoardDetailPage() {
   if (error || !detail) {
     return (
       <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
-        <p className="typo-pc-b2 text-red">{error ?? '글을 불러오지 못했습니다.'}</p>
-        <Link href="/board/events/" className="mt-4 inline-block underline typo-pc-b3">
+        <p className="typo-pc-b2 mobile:typo-m-b2 text-red">{error ?? '글을 불러오지 못했습니다.'}</p>
+        <Link href="/board/events/" className="mt-4 inline-block underline typo-pc-b3 mobile:typo-m-b3">
           목록으로
         </Link>
       </main>
@@ -122,14 +122,14 @@ export default function EventBoardDetailPage() {
           url: user ? '/profile/' : '/login?next=%2Fboard%2Fevents%2F'
         }}
       />
-      <div className="mx-auto w-full max-w-[880px] space-y-6 px-6 py-10">
-        <Link href="/board/events/" className="typo-pc-c2 text-gray-700 hover:text-white">
+      <div className="mx-auto w-full max-w-[880px] space-y-6 px-6 mobile:px-4 py-10">
+        <Link href="/board/events/" className="typo-pc-c2 mobile:typo-m-c2 text-gray-700 hover:text-white">
           목록으로
         </Link>
 
         <div className="space-y-2">
           <h1 className="typo-pc-h3 mobile:typo-m-h2">{detail.title}</h1>
-          <div className="flex flex-wrap gap-4 text-gray-500 typo-pc-c1">
+          <div className="flex flex-wrap gap-4 text-gray-500 typo-pc-c1 mobile:typo-m-c1">
             <span>
               {formatDate(detail.eventStartDate)} ~ {formatDate(detail.eventEndDate)}
             </span>
@@ -145,7 +145,7 @@ export default function EventBoardDetailPage() {
           </div>
         )}
 
-        <p className="whitespace-pre-wrap typo-pc-b2">{detail.content}</p>
+        <p className="whitespace-pre-wrap typo-pc-b2 mobile:typo-m-b2">{detail.content}</p>
 
         <AttachmentList attachments={detail.attachments} />
 
@@ -153,7 +153,7 @@ export default function EventBoardDetailPage() {
           <div className="flex gap-3 border-t border-gray-800 pt-6">
             <Link
               href={`/board/events/edit?id=${detail.id}`}
-              className="rounded-full border border-gray-800 px-6 py-2 typo-pc-b3"
+              className="rounded-full border border-gray-800 px-6 py-2 typo-pc-b3 mobile:typo-m-b3"
             >
               수정
             </Link>
@@ -161,7 +161,7 @@ export default function EventBoardDetailPage() {
               type="button"
               onClick={handleDelete}
               disabled={deleting}
-              className="rounded-full border border-red px-6 py-2 text-red typo-pc-b3 disabled:opacity-50"
+              className="rounded-full border border-red px-6 py-2 text-red typo-pc-b3 mobile:typo-m-b3 disabled:opacity-50"
             >
               삭제
             </button>

--- a/src/app/board/events/edit/page.tsx
+++ b/src/app/board/events/edit/page.tsx
@@ -14,6 +14,7 @@ import {
   GdgTextarea,
   type GdgDropdownOption
 } from '@/components/ui/design-system'
+import { BOARD_MENUS } from '@/components/board/boardMenus'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
 import { fetchEventDetail, updateEvent } from '@/services/board/boardClient'
@@ -212,7 +213,7 @@ export default function EventBoardEditPage() {
   return (
     <main className="min-h-screen bg-black text-white">
       <GdgSiteHeader
-        menus={[{ label: '게시판', url: '/board/events/' }]}
+        menus={BOARD_MENUS}
         actionMenu={{ label: '내 정보', url: '/profile/' }}
       />
       <div className="mx-auto w-full max-w-[720px] space-y-6 px-6 py-10">

--- a/src/app/board/events/edit/page.tsx
+++ b/src/app/board/events/edit/page.tsx
@@ -193,19 +193,19 @@ export default function EventBoardEditPage() {
   if (!hasAtLeast(user?.userRole, 'CORE')) {
     return (
       <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
-        <p className="typo-pc-b2">수정 권한이 없습니다.</p>
+        <p className="typo-pc-b2 mobile:typo-m-b2">수정 권한이 없습니다.</p>
       </main>
     )
   }
 
   if (loading) {
-    return <p className="py-16 text-center text-white typo-pc-b2">불러오는 중...</p>
+    return <p className="py-16 text-center text-white typo-pc-b2 mobile:typo-m-b2">불러오는 중...</p>
   }
 
   if (loadError) {
     return (
       <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
-        <p className="typo-pc-b2 text-red">{loadError}</p>
+        <p className="typo-pc-b2 mobile:typo-m-b2 text-red">{loadError}</p>
       </main>
     )
   }
@@ -216,7 +216,7 @@ export default function EventBoardEditPage() {
         menus={BOARD_MENUS}
         actionMenu={{ label: '내 정보', url: '/profile/' }}
       />
-      <div className="mx-auto w-full max-w-[720px] space-y-6 px-6 py-10">
+      <div className="mx-auto w-full max-w-[720px] space-y-6 px-6 mobile:px-4 py-10">
         <h1 className="typo-pc-h3 mobile:typo-m-h2">행사 게시글 수정</h1>
 
         <GdgInputField
@@ -228,7 +228,7 @@ export default function EventBoardEditPage() {
 
         <div className="flex gap-4">
           <label className="flex flex-1 flex-col gap-2">
-            <span className="typo-pc-s3 uppercase tracking-[0.2em] text-white/80">시작일</span>
+            <span className="typo-pc-s3 mobile:typo-m-s3 uppercase tracking-[0.2em] text-white/80">시작일</span>
             <input
               type="date"
               value={eventStartDate}
@@ -237,7 +237,7 @@ export default function EventBoardEditPage() {
             />
           </label>
           <label className="flex flex-1 flex-col gap-2">
-            <span className="typo-pc-s3 uppercase tracking-[0.2em] text-white/80">종료일</span>
+            <span className="typo-pc-s3 mobile:typo-m-s3 uppercase tracking-[0.2em] text-white/80">종료일</span>
             <input
               type="date"
               value={eventEndDate}
@@ -255,7 +255,7 @@ export default function EventBoardEditPage() {
         />
 
         <div className="flex flex-col gap-2">
-          <span className="typo-pc-s3 uppercase tracking-[0.2em] text-white/80">썸네일</span>
+          <span className="typo-pc-s3 mobile:typo-m-s3 uppercase tracking-[0.2em] text-white/80">썸네일</span>
           <input
             ref={thumbnailInputRef}
             type="file"
@@ -285,7 +285,7 @@ export default function EventBoardEditPage() {
           onChange={(event) => setContent(event.target.value)}
         />
 
-        <label className="flex items-center gap-2 typo-pc-b3">
+        <label className="flex items-center gap-2 typo-pc-b3 mobile:typo-m-b3">
           <input
             type="checkbox"
             checked={isPublished}
@@ -295,7 +295,7 @@ export default function EventBoardEditPage() {
         </label>
 
         <div className="flex flex-col gap-2">
-          <span className="typo-pc-s3 uppercase tracking-[0.2em] text-white/80">첨부</span>
+          <span className="typo-pc-s3 mobile:typo-m-s3 uppercase tracking-[0.2em] text-white/80">첨부</span>
           <AttachmentUploader
             attachments={attachments}
             onChange={setAttachments}
@@ -304,7 +304,7 @@ export default function EventBoardEditPage() {
           />
         </div>
 
-        {errorMessage && <p className="typo-pc-b3 text-red">{errorMessage}</p>}
+        {errorMessage && <p className="typo-pc-b3 mobile:typo-m-b3 text-red">{errorMessage}</p>}
 
         <GdgButton variant="active" fullWidth onClick={handleSubmit} loading={submitting}>
           저장

--- a/src/app/board/events/edit/page.tsx
+++ b/src/app/board/events/edit/page.tsx
@@ -248,6 +248,8 @@ export default function EventBoardEditPage() {
         </div>
 
         <GdgDropdown
+          // 기본 size=small(122px) 은 플레이스홀더를 담지 못하고 잘린다.
+          size="medium"
           label="주최 팀"
           options={TEAM_OPTIONS}
           value={organizingTeam}

--- a/src/app/board/events/new/page.tsx
+++ b/src/app/board/events/new/page.tsx
@@ -14,6 +14,7 @@ import {
   GdgTextarea,
   type GdgDropdownOption
 } from '@/components/ui/design-system'
+import { BOARD_MENUS } from '@/components/board/boardMenus'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
 import { createEvent } from '@/services/board/boardClient'
@@ -135,7 +136,7 @@ export default function EventBoardNewPage() {
   return (
     <main className="min-h-screen bg-black text-white">
       <GdgSiteHeader
-        menus={[{ label: '게시판', url: '/board/events/' }]}
+        menus={BOARD_MENUS}
         actionMenu={{ label: '내 정보', url: '/profile/' }}
       />
       <div className="mx-auto w-full max-w-[720px] space-y-6 px-6 py-10">

--- a/src/app/board/events/new/page.tsx
+++ b/src/app/board/events/new/page.tsx
@@ -128,7 +128,7 @@ export default function EventBoardNewPage() {
   if (!hasAtLeast(user?.userRole, 'CORE')) {
     return (
       <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
-        <p className="typo-pc-b2">글쓰기 권한이 없습니다.</p>
+        <p className="typo-pc-b2 mobile:typo-m-b2">글쓰기 권한이 없습니다.</p>
       </main>
     )
   }
@@ -139,7 +139,7 @@ export default function EventBoardNewPage() {
         menus={BOARD_MENUS}
         actionMenu={{ label: '내 정보', url: '/profile/' }}
       />
-      <div className="mx-auto w-full max-w-[720px] space-y-6 px-6 py-10">
+      <div className="mx-auto w-full max-w-[720px] space-y-6 px-6 mobile:px-4 py-10">
         <h1 className="typo-pc-h3 mobile:typo-m-h2">행사 게시글 작성</h1>
 
         <GdgInputField
@@ -151,7 +151,7 @@ export default function EventBoardNewPage() {
 
         <div className="flex gap-4">
           <label className="flex flex-1 flex-col gap-2">
-            <span className="typo-pc-s3 uppercase tracking-[0.2em] text-white/80">시작일</span>
+            <span className="typo-pc-s3 mobile:typo-m-s3 uppercase tracking-[0.2em] text-white/80">시작일</span>
             <input
               type="date"
               value={eventStartDate}
@@ -160,7 +160,7 @@ export default function EventBoardNewPage() {
             />
           </label>
           <label className="flex flex-1 flex-col gap-2">
-            <span className="typo-pc-s3 uppercase tracking-[0.2em] text-white/80">종료일</span>
+            <span className="typo-pc-s3 mobile:typo-m-s3 uppercase tracking-[0.2em] text-white/80">종료일</span>
             <input
               type="date"
               value={eventEndDate}
@@ -178,7 +178,7 @@ export default function EventBoardNewPage() {
         />
 
         <div className="flex flex-col gap-2">
-          <span className="typo-pc-s3 uppercase tracking-[0.2em] text-white/80">썸네일</span>
+          <span className="typo-pc-s3 mobile:typo-m-s3 uppercase tracking-[0.2em] text-white/80">썸네일</span>
           <input
             ref={thumbnailInputRef}
             type="file"
@@ -208,7 +208,7 @@ export default function EventBoardNewPage() {
           onChange={(event) => setContent(event.target.value)}
         />
 
-        <label className="flex items-center gap-2 typo-pc-b3">
+        <label className="flex items-center gap-2 typo-pc-b3 mobile:typo-m-b3">
           <input
             type="checkbox"
             checked={isPublished}
@@ -218,7 +218,7 @@ export default function EventBoardNewPage() {
         </label>
 
         <div className="flex flex-col gap-2">
-          <span className="typo-pc-s3 uppercase tracking-[0.2em] text-white/80">첨부</span>
+          <span className="typo-pc-s3 mobile:typo-m-s3 uppercase tracking-[0.2em] text-white/80">첨부</span>
           <AttachmentUploader
             attachments={attachments}
             onChange={setAttachments}
@@ -227,7 +227,7 @@ export default function EventBoardNewPage() {
           />
         </div>
 
-        {errorMessage && <p className="typo-pc-b3 text-red">{errorMessage}</p>}
+        {errorMessage && <p className="typo-pc-b3 mobile:typo-m-b3 text-red">{errorMessage}</p>}
 
         <GdgButton variant="active" fullWidth onClick={handleSubmit} loading={submitting}>
           등록

--- a/src/app/board/events/new/page.tsx
+++ b/src/app/board/events/new/page.tsx
@@ -171,6 +171,8 @@ export default function EventBoardNewPage() {
         </div>
 
         <GdgDropdown
+          // 기본 size=small(122px) 은 플레이스홀더를 담지 못하고 잘린다.
+          size="medium"
           label="주최 팀"
           options={TEAM_OPTIONS}
           value={organizingTeam}

--- a/src/app/board/events/page.tsx
+++ b/src/app/board/events/page.tsx
@@ -92,13 +92,13 @@ export default function EventBoardListPage() {
           url: user ? '/profile/' : '/login?next=%2Fboard%2Fevents%2F'
         }}
       />
-      <div className="mx-auto w-full max-w-[1120px] space-y-6 px-6 py-10">
-        <div className="flex items-center justify-between">
+      <div className="mx-auto w-full max-w-[1120px] space-y-6 px-6 mobile:px-4 py-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <h1 className="typo-pc-h3 mobile:typo-m-h2">행사 게시판</h1>
           {canWrite && (
             <Link
               href="/board/events/new/"
-              className="rounded-full bg-red px-6 py-2 typo-pc-b3 text-white"
+              className="rounded-full bg-red px-6 py-2 typo-pc-b3 mobile:typo-m-b3 text-white"
             >
               글쓰기
             </Link>
@@ -117,9 +117,9 @@ export default function EventBoardListPage() {
           onSubmit={handleSubmitSearch}
         />
 
-        {error && <p className="typo-pc-b3 text-red">{error}</p>}
+        {error && <p className="typo-pc-b3 mobile:typo-m-b3 text-red">{error}</p>}
         {loading ? (
-          <p className="py-16 text-center text-gray-500 typo-pc-b2">불러오는 중...</p>
+          <p className="py-16 text-center text-gray-500 typo-pc-b2 mobile:typo-m-b2">불러오는 중...</p>
         ) : (
           <BoardList
             items={items}

--- a/src/app/board/events/page.tsx
+++ b/src/app/board/events/page.tsx
@@ -70,7 +70,7 @@ export default function EventBoardListPage() {
   }, [keyword])
 
   const columns: BoardListColumn<EventBoardSummary>[] = [
-    { key: 'title', header: '제목', render: (item) => item.title },
+    { key: 'title', header: '제목', render: (item) => item.title, primary: true },
     {
       key: 'period',
       header: '기간',

--- a/src/app/board/events/page.tsx
+++ b/src/app/board/events/page.tsx
@@ -8,6 +8,7 @@ import { BoardList, type BoardListColumn } from '@/components/board/BoardList'
 import { BoardPagination } from '@/components/board/BoardPagination'
 import { BoardSearchBar } from '@/components/board/BoardSearchBar'
 import { GdgSiteHeader } from '@/components/ui/design-system'
+import { BOARD_MENUS } from '@/components/board/boardMenus'
 import { useAuth } from '@/hooks/useAuth'
 import { fetchEventList } from '@/services/board/boardClient'
 import type { EventBoardSummary, EventSearchType } from '@/types/board'
@@ -85,7 +86,7 @@ export default function EventBoardListPage() {
   return (
     <main className="min-h-screen bg-black text-white">
       <GdgSiteHeader
-        menus={[{ label: '게시판', url: '/board/events/' }]}
+        menus={BOARD_MENUS}
         actionMenu={{
           label: user ? '내 정보' : '로그인',
           url: user ? '/profile/' : '/login?next=%2Fboard%2Fevents%2F'

--- a/src/app/board/notices/detail/page.tsx
+++ b/src/app/board/notices/detail/page.tsx
@@ -109,8 +109,8 @@ export default function NoticeBoardDetailPage() {
   if (notFound) {
     return (
       <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
-        <p className="typo-pc-b2">삭제되었거나 존재하지 않는 공지입니다.</p>
-        <Link href="/board/notices/" className="mt-4 inline-block underline typo-pc-b3">
+        <p className="typo-pc-b2 mobile:typo-m-b2">삭제되었거나 존재하지 않는 공지입니다.</p>
+        <Link href="/board/notices/" className="mt-4 inline-block underline typo-pc-b3 mobile:typo-m-b3">
           목록으로
         </Link>
       </main>
@@ -120,8 +120,8 @@ export default function NoticeBoardDetailPage() {
   if (error || !detail) {
     return (
       <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
-        <p className="text-red typo-pc-b2">{error ?? '글을 불러오지 못했습니다.'}</p>
-        <Link href="/board/notices/" className="mt-4 inline-block underline typo-pc-b3">
+        <p className="text-red typo-pc-b2 mobile:typo-m-b2">{error ?? '글을 불러오지 못했습니다.'}</p>
+        <Link href="/board/notices/" className="mt-4 inline-block underline typo-pc-b3 mobile:typo-m-b3">
           목록으로
         </Link>
       </main>
@@ -131,18 +131,18 @@ export default function NoticeBoardDetailPage() {
   return (
     <main className="min-h-screen bg-black text-white">
       <GdgSiteHeader menus={BOARD_MENUS} actionMenu={{ label: '내 정보', url: '/profile/' }} />
-      <div className="mx-auto w-full max-w-[880px] space-y-6 px-6 py-10">
-        <Link href="/board/notices/" className="text-gray-700 typo-pc-c2 hover:text-white">
+      <div className="mx-auto w-full max-w-[880px] space-y-6 px-6 mobile:px-4 py-10">
+        <Link href="/board/notices/" className="text-gray-700 typo-pc-c2 mobile:typo-m-c2 hover:text-white">
           목록으로
         </Link>
 
         <div className="space-y-2">
           <div className="flex items-center gap-2">
             <NoticeCategoryTag category={detail.category} />
-            {!detail.isPublished && <span className="text-gray-700 typo-pc-c2">임시저장</span>}
+            {!detail.isPublished && <span className="text-gray-700 typo-pc-c2 mobile:typo-m-c2">임시저장</span>}
           </div>
           <h1 className="typo-pc-h3 mobile:typo-m-h2">{detail.title}</h1>
-          <div className="flex flex-wrap gap-4 text-gray-500 typo-pc-c1">
+          <div className="flex flex-wrap gap-4 text-gray-500 typo-pc-c1 mobile:typo-m-c1">
             <span>{detail.authorName}</span>
             <span>{formatDate(detail.createdAt)}</span>
             {/* 조회수는 서버가 상세 조회마다 +1 한다. 이 값은 이번 조회가 반영된 뒤의 수치다. */}
@@ -150,7 +150,7 @@ export default function NoticeBoardDetailPage() {
           </div>
         </div>
 
-        <p className="whitespace-pre-wrap typo-pc-b2">{detail.content}</p>
+        <p className="whitespace-pre-wrap typo-pc-b2 mobile:typo-m-b2">{detail.content}</p>
 
         <AttachmentList attachments={detail.attachments} />
 
@@ -162,7 +162,7 @@ export default function NoticeBoardDetailPage() {
           <div className="flex gap-3 border-t border-gray-800 pt-6">
             <Link
               href={`/board/notices/edit?id=${detail.id}`}
-              className="rounded-full border border-gray-800 px-6 py-2 typo-pc-b3"
+              className="rounded-full border border-gray-800 px-6 py-2 typo-pc-b3 mobile:typo-m-b3"
             >
               수정
             </Link>
@@ -170,7 +170,7 @@ export default function NoticeBoardDetailPage() {
               type="button"
               onClick={handleDelete}
               disabled={deleting}
-              className="rounded-full border border-red px-6 py-2 text-red typo-pc-b3 disabled:opacity-50"
+              className="rounded-full border border-red px-6 py-2 text-red typo-pc-b3 mobile:typo-m-b3 disabled:opacity-50"
             >
               삭제
             </button>

--- a/src/app/board/notices/detail/page.tsx
+++ b/src/app/board/notices/detail/page.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { AttachmentList } from '@/components/board/AttachmentList'
 import { NoticeCategoryTag } from '@/components/board/NoticeCategoryTag'
 import { GdgSiteHeader } from '@/components/ui/design-system'
+import { BOARD_MENUS } from '@/components/board/boardMenus'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
 import { deleteNotice, fetchNoticeDetail } from '@/services/board/noticeClient'
@@ -31,8 +32,19 @@ export default function NoticeBoardDetailPage() {
   const [deleting, setDeleting] = useState(false)
 
   const canManage = hasAtLeast(user?.userRole, 'CORE')
+  // 공지는 회원 전용이다. 목록과 같은 게이트를 상세에도 건다 — 링크로 직접 들어올 수 있다.
+  const isLoggedIn = Boolean(user)
 
   useEffect(() => {
+    if (isLoggedIn) return
+    router.replace(
+      `/login?next=${encodeURIComponent(idParam ? `/board/notices/detail/?id=${idParam}` : '/board/notices/')}`
+    )
+  }, [idParam, isLoggedIn, router])
+
+  useEffect(() => {
+    if (!isLoggedIn) return
+
     if (!Number.isFinite(id)) {
       setLoading(false)
       setError('잘못된 접근입니다.')
@@ -44,8 +56,8 @@ export default function NoticeBoardDetailPage() {
     setError(null)
     setNotFound(false)
 
-    // 미공개 글은 서버가 CORE 미만에게 404를 준다. CORE 이상은 토큰을 실어야 자기 초안을 연다.
-    fetchNoticeDetail(id, canManage ? apiClient : undefined)
+    // 미공개 글은 서버가 CORE 미만에게 404를 준다. CORE 이상은 자기 초안까지 열린다.
+    fetchNoticeDetail(id, apiClient)
       .then((data) => {
         if (alive) setDetail(data)
       })
@@ -64,7 +76,7 @@ export default function NoticeBoardDetailPage() {
     return () => {
       alive = false
     }
-  }, [apiClient, canManage, id])
+  }, [apiClient, id, isLoggedIn])
 
   const handleDelete = useCallback(async () => {
     if (!Number.isFinite(id)) return
@@ -81,8 +93,17 @@ export default function NoticeBoardDetailPage() {
     }
   }, [apiClient, id, router])
 
+  // 로그인으로 보내는 사이 그려지는 한 프레임. "불러오는 중"으로 두면 실패로 오해한다.
+  if (!isLoggedIn) {
+    return (
+      <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
+        <p className="typo-pc-b2 mobile:typo-m-b2">로그인이 필요한 게시판입니다.</p>
+      </main>
+    )
+  }
+
   if (loading) {
-    return <p className="py-16 text-center text-white typo-pc-b2">불러오는 중...</p>
+    return <p className="py-16 text-center text-white typo-pc-b2 mobile:typo-m-b2">불러오는 중...</p>
   }
 
   if (notFound) {
@@ -109,13 +130,7 @@ export default function NoticeBoardDetailPage() {
 
   return (
     <main className="min-h-screen bg-black text-white">
-      <GdgSiteHeader
-        menus={[{ label: '게시판', url: '/board/notices/' }]}
-        actionMenu={{
-          label: user ? '내 정보' : '로그인',
-          url: user ? '/profile/' : '/login?next=%2Fboard%2Fnotices%2F'
-        }}
-      />
+      <GdgSiteHeader menus={BOARD_MENUS} actionMenu={{ label: '내 정보', url: '/profile/' }} />
       <div className="mx-auto w-full max-w-[880px] space-y-6 px-6 py-10">
         <Link href="/board/notices/" className="text-gray-700 typo-pc-c2 hover:text-white">
           목록으로

--- a/src/app/board/notices/edit/page.tsx
+++ b/src/app/board/notices/edit/page.tsx
@@ -134,19 +134,19 @@ export default function NoticeBoardEditPage() {
   if (!canManage) {
     return (
       <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
-        <p className="typo-pc-b2">수정 권한이 없습니다.</p>
+        <p className="typo-pc-b2 mobile:typo-m-b2">수정 권한이 없습니다.</p>
       </main>
     )
   }
 
   if (loading) {
-    return <p className="py-16 text-center text-white typo-pc-b2">불러오는 중...</p>
+    return <p className="py-16 text-center text-white typo-pc-b2 mobile:typo-m-b2">불러오는 중...</p>
   }
 
   if (loadError) {
     return (
       <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
-        <p className="text-red typo-pc-b2">{loadError}</p>
+        <p className="text-red typo-pc-b2 mobile:typo-m-b2">{loadError}</p>
       </main>
     )
   }
@@ -157,7 +157,7 @@ export default function NoticeBoardEditPage() {
         menus={BOARD_MENUS}
         actionMenu={{ label: '내 정보', url: '/profile/' }}
       />
-      <div className="mx-auto w-full max-w-[720px] space-y-6 px-6 py-10">
+      <div className="mx-auto w-full max-w-[720px] space-y-6 px-6 mobile:px-4 py-10">
         <h1 className="typo-pc-h3 mobile:typo-m-h2">공지사항 수정</h1>
 
         <GdgInputField
@@ -187,7 +187,7 @@ export default function NoticeBoardEditPage() {
             백엔드는 고정 '저장 시점'에만 미공개를 거부하고(PinnedNoticeService.replacePinned),
             이미 고정된 글이 나중에 미공개로 바뀌는 경로는 막지 않는다. 프론트가 할 수 있는
             일이 없어 관측한 사실로만 남긴다. */}
-        <label className="flex items-center gap-2 typo-pc-b3">
+        <label className="flex items-center gap-2 typo-pc-b3 mobile:typo-m-b3">
           <input
             type="checkbox"
             checked={isPublished}
@@ -197,7 +197,7 @@ export default function NoticeBoardEditPage() {
         </label>
 
         <div className="flex flex-col gap-2">
-          <span className="tracking-[0.2em] text-white/80 typo-pc-s3 uppercase">첨부</span>
+          <span className="tracking-[0.2em] text-white/80 typo-pc-s3 mobile:typo-m-s3 uppercase">첨부</span>
           <AttachmentUploader
             attachments={attachments}
             onChange={setAttachments}
@@ -206,7 +206,7 @@ export default function NoticeBoardEditPage() {
           />
         </div>
 
-        {errorMessage && <p className="text-red typo-pc-b3">{errorMessage}</p>}
+        {errorMessage && <p className="text-red typo-pc-b3 mobile:typo-m-b3">{errorMessage}</p>}
 
         <GdgButton variant="active" fullWidth onClick={handleSubmit} loading={submitting}>
           저장

--- a/src/app/board/notices/edit/page.tsx
+++ b/src/app/board/notices/edit/page.tsx
@@ -13,6 +13,7 @@ import {
   GdgTextarea,
   type GdgDropdownOption
 } from '@/components/ui/design-system'
+import { BOARD_MENUS } from '@/components/board/boardMenus'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
 import { fetchNoticeDetail, updateNotice } from '@/services/board/noticeClient'
@@ -153,7 +154,7 @@ export default function NoticeBoardEditPage() {
   return (
     <main className="min-h-screen bg-black text-white">
       <GdgSiteHeader
-        menus={[{ label: '게시판', url: '/board/notices/' }]}
+        menus={BOARD_MENUS}
         actionMenu={{ label: '내 정보', url: '/profile/' }}
       />
       <div className="mx-auto w-full max-w-[720px] space-y-6 px-6 py-10">

--- a/src/app/board/notices/edit/page.tsx
+++ b/src/app/board/notices/edit/page.tsx
@@ -168,6 +168,8 @@ export default function NoticeBoardEditPage() {
         />
 
         <GdgDropdown
+          // 기본 size=small(122px) 은 플레이스홀더를 담지 못하고 잘린다.
+          size="medium"
           label="분류"
           placeholder="분류를 선택하세요"
           options={CATEGORY_OPTIONS}

--- a/src/app/board/notices/new/page.tsx
+++ b/src/app/board/notices/new/page.tsx
@@ -79,7 +79,7 @@ export default function NoticeBoardNewPage() {
   if (!hasAtLeast(user?.userRole, 'CORE')) {
     return (
       <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
-        <p className="typo-pc-b2">글쓰기 권한이 없습니다.</p>
+        <p className="typo-pc-b2 mobile:typo-m-b2">글쓰기 권한이 없습니다.</p>
       </main>
     )
   }
@@ -90,7 +90,7 @@ export default function NoticeBoardNewPage() {
         menus={BOARD_MENUS}
         actionMenu={{ label: '내 정보', url: '/profile/' }}
       />
-      <div className="mx-auto w-full max-w-[720px] space-y-6 px-6 py-10">
+      <div className="mx-auto w-full max-w-[720px] space-y-6 px-6 mobile:px-4 py-10">
         <h1 className="typo-pc-h3 mobile:typo-m-h2">공지사항 작성</h1>
 
         <GdgInputField
@@ -117,7 +117,7 @@ export default function NoticeBoardNewPage() {
         />
 
         {/* 임시저장은 별도 status가 아니라 isPublished=false 하나로 표현된다 (백엔드 설계 §3). */}
-        <label className="flex items-center gap-2 typo-pc-b3">
+        <label className="flex items-center gap-2 typo-pc-b3 mobile:typo-m-b3">
           <input
             type="checkbox"
             checked={isPublished}
@@ -127,7 +127,7 @@ export default function NoticeBoardNewPage() {
         </label>
 
         <div className="flex flex-col gap-2">
-          <span className="tracking-[0.2em] text-white/80 typo-pc-s3 uppercase">첨부</span>
+          <span className="tracking-[0.2em] text-white/80 typo-pc-s3 mobile:typo-m-s3 uppercase">첨부</span>
           <AttachmentUploader
             attachments={attachments}
             onChange={setAttachments}
@@ -136,7 +136,7 @@ export default function NoticeBoardNewPage() {
           />
         </div>
 
-        {errorMessage && <p className="text-red typo-pc-b3">{errorMessage}</p>}
+        {errorMessage && <p className="text-red typo-pc-b3 mobile:typo-m-b3">{errorMessage}</p>}
 
         <GdgButton variant="active" fullWidth onClick={handleSubmit} loading={submitting}>
           등록

--- a/src/app/board/notices/new/page.tsx
+++ b/src/app/board/notices/new/page.tsx
@@ -101,6 +101,8 @@ export default function NoticeBoardNewPage() {
         />
 
         <GdgDropdown
+          // 기본 size=small(122px) 은 플레이스홀더를 담지 못하고 잘린다.
+          size="medium"
           label="분류"
           placeholder="분류를 선택하세요"
           options={CATEGORY_OPTIONS}

--- a/src/app/board/notices/new/page.tsx
+++ b/src/app/board/notices/new/page.tsx
@@ -13,6 +13,7 @@ import {
   GdgTextarea,
   type GdgDropdownOption
 } from '@/components/ui/design-system'
+import { BOARD_MENUS } from '@/components/board/boardMenus'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
 import { createNotice } from '@/services/board/noticeClient'
@@ -86,7 +87,7 @@ export default function NoticeBoardNewPage() {
   return (
     <main className="min-h-screen bg-black text-white">
       <GdgSiteHeader
-        menus={[{ label: '게시판', url: '/board/notices/' }]}
+        menus={BOARD_MENUS}
         actionMenu={{ label: '내 정보', url: '/profile/' }}
       />
       <div className="mx-auto w-full max-w-[720px] space-y-6 px-6 py-10">

--- a/src/app/board/notices/page.tsx
+++ b/src/app/board/notices/page.tsx
@@ -105,7 +105,7 @@ export default function NoticeBoardListPage() {
           {item.title}
           {/* 서버가 CORE 미만에게는 미공개 글을 아예 주지 않으므로, 이 배지가 보인다는 건
               보는 사람이 CORE 이상이라는 뜻이다. */}
-          {!item.isPublished && <span className="shrink-0 text-gray-700 typo-pc-c2">임시저장</span>}
+          {!item.isPublished && <span className="shrink-0 text-gray-700 typo-pc-c2 mobile:typo-m-c2">임시저장</span>}
         </span>
       )
     },
@@ -135,15 +135,15 @@ export default function NoticeBoardListPage() {
         menus={BOARD_MENUS}
         actionMenu={{ label: '내 정보', url: '/profile/' }}
       />
-      <div className="mx-auto w-full max-w-[1120px] space-y-6 px-6 py-10">
-        <div className="flex items-center justify-between">
+      <div className="mx-auto w-full max-w-[1120px] space-y-6 px-6 mobile:px-4 py-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <h1 className="typo-pc-h3 mobile:typo-m-h2">공지사항</h1>
           <div className="flex items-center gap-3">
             {canPin && (
               <button
                 type="button"
                 onClick={() => setPinnedModalOpen(true)}
-                className="rounded-full border border-gray-800 px-6 py-2 typo-pc-b3"
+                className="rounded-full border border-gray-800 px-6 py-2 typo-pc-b3 mobile:typo-m-b3"
               >
                 상단 고정 관리
               </button>
@@ -151,7 +151,7 @@ export default function NoticeBoardListPage() {
             {canWrite && (
               <Link
                 href="/board/notices/new/"
-                className="rounded-full bg-red px-6 py-2 text-white typo-pc-b3"
+                className="rounded-full bg-red px-6 py-2 text-white typo-pc-b3 mobile:typo-m-b3"
               >
                 글쓰기
               </Link>
@@ -171,7 +171,7 @@ export default function NoticeBoardListPage() {
           onSubmit={handleSubmitSearch}
         />
 
-        {error && <p className="text-red typo-pc-b3">{error}</p>}
+        {error && <p className="text-red typo-pc-b3 mobile:typo-m-b3">{error}</p>}
 
         {/* 고정 공지는 size=15와 별개 필드이며, 아래 일반 목록에도 같은 글이 나올 수 있다.
             구형 게시판의 통상적 동작이고 백엔드 설계 §7.1이 의도한 것이다. */}
@@ -181,19 +181,19 @@ export default function NoticeBoardListPage() {
               <li key={notice.id}>
                 <Link
                   href={`/board/notices/detail?id=${notice.id}`}
-                  className="flex items-center gap-3 py-1 typo-pc-b3 hover:underline"
+                  className="flex items-center gap-3 py-1 typo-pc-b3 mobile:typo-m-b3 hover:underline"
                 >
                   <span aria-hidden>📌</span>
                   <NoticeCategoryTag category={notice.category} />
                   <span className="flex-1 truncate">{notice.title}</span>
-                  <span className="shrink-0 text-gray-500 typo-pc-c1">{notice.authorName}</span>
+                  <span className="shrink-0 text-gray-500 typo-pc-c1 mobile:typo-m-c1">{notice.authorName}</span>
                 </Link>
               </li>
             ))}
           </ul>
         )}
 
-        {loading && <p className="py-16 text-center text-gray-500 typo-pc-b2">불러오는 중...</p>}
+        {loading && <p className="py-16 text-center text-gray-500 typo-pc-b2 mobile:typo-m-b2">불러오는 중...</p>}
         {/* 실패했을 때는 목록을 그리지 않는다. 빈 배열을 넘기면 "등록된 공지가 없습니다."가
             에러 메시지와 나란히 떠서, 못 불러온 것인지 정말 없는 것인지 구분이 안 된다. */}
         {!loading && !error && (

--- a/src/app/board/notices/page.tsx
+++ b/src/app/board/notices/page.tsx
@@ -99,6 +99,7 @@ export default function NoticeBoardListPage() {
     {
       key: 'title',
       header: '제목',
+      primary: true,
       render: (item) => (
         <span className="flex items-center gap-2">
           {item.title}

--- a/src/app/board/notices/page.tsx
+++ b/src/app/board/notices/page.tsx
@@ -10,6 +10,7 @@ import { BoardSearchBar } from '@/components/board/BoardSearchBar'
 import { NoticeCategoryTag } from '@/components/board/NoticeCategoryTag'
 import { PinnedNoticeModal } from '@/components/board/PinnedNoticeModal'
 import { GdgSiteHeader } from '@/components/ui/design-system'
+import { BOARD_MENUS } from '@/components/board/boardMenus'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
 import { fetchNoticeList } from '@/services/board/noticeClient'
@@ -46,18 +47,25 @@ export default function NoticeBoardListPage() {
   const canWrite = hasAtLeast(user?.userRole, 'CORE')
   // 글쓰기(CORE)와 고정 관리(ORGANIZER)는 권한 경계가 다르다.
   const canPin = hasAtLeast(user?.userRole, 'ORGANIZER')
+  // 공지는 회원 전용이다. 행사 게시판과 달리 비로그인은 목록조차 볼 수 없다.
+  const isLoggedIn = Boolean(user)
 
   useEffect(() => {
+    if (isLoggedIn) return
+    router.replace(`/login?next=${encodeURIComponent('/board/notices/')}`)
+  }, [isLoggedIn, router])
+
+  useEffect(() => {
+    // 게이트가 로그인으로 보내는 중이다. 여기서 조회하면 토큰 없이 나간다.
+    if (!isLoggedIn) return
+
     let alive = true
     setLoading(true)
     setError(null)
 
-    // CORE 이상만 토큰을 실어 보낸다. 그래야 임시저장(isPublished=false)이 목록에 보인다.
-    // 비로그인 방문자에게 apiClient를 쓰면 401 인터셉터가 /login으로 튕긴다.
-    fetchNoticeList(
-      { page, size: 15, searchType, keyword: submittedKeyword },
-      canWrite ? apiClient : undefined
-    )
+    // 로그인했으면 항상 토큰을 실어 보낸다. CORE 이상이면 서버가 자기
+    // 임시저장(isPublished=false)까지 함께 내려준다.
+    fetchNoticeList({ page, size: 15, searchType, keyword: submittedKeyword }, apiClient)
       .then((result) => {
         if (!alive) return
         setPinned(result.pinned)
@@ -74,7 +82,7 @@ export default function NoticeBoardListPage() {
     return () => {
       alive = false
     }
-  }, [apiClient, canWrite, page, searchType, submittedKeyword, reloadKey])
+  }, [apiClient, isLoggedIn, page, searchType, submittedKeyword, reloadKey])
 
   const handleSubmitSearch = useCallback(() => {
     setPage(0)
@@ -110,14 +118,21 @@ export default function NoticeBoardListPage() {
     }
   ]
 
+  // 위 useEffect가 로그인으로 보내는 사이 한 프레임이 그려진다. 목록 골격 대신
+  // 안내를 띄워야 "빈 게시판"으로 오해하지 않는다.
+  if (!isLoggedIn) {
+    return (
+      <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
+        <p className="typo-pc-b2 mobile:typo-m-b2">로그인이 필요한 게시판입니다.</p>
+      </main>
+    )
+  }
+
   return (
     <main className="min-h-screen bg-black text-white">
       <GdgSiteHeader
-        menus={[{ label: '공지사항', url: '/board/notices/' }]}
-        actionMenu={{
-          label: user ? '내 정보' : '로그인',
-          url: user ? '/profile/' : '/login?next=%2Fboard%2Fnotices%2F'
-        }}
+        menus={BOARD_MENUS}
+        actionMenu={{ label: '내 정보', url: '/profile/' }}
       />
       <div className="mx-auto w-full max-w-[1120px] space-y-6 px-6 py-10">
         <div className="flex items-center justify-between">

--- a/src/components/board/AttachmentList.tsx
+++ b/src/components/board/AttachmentList.tsx
@@ -31,7 +31,7 @@ export function AttachmentList({ attachments }: AttachmentListProps) {
               href={attachment.fileUrl ?? '#'}
               target="_blank"
               rel="noreferrer"
-              className="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-white typo-pc-b3 transition-colors hover:bg-gray-400"
+              className="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-white typo-pc-b3 mobile:typo-m-b3 transition-colors hover:bg-gray-400"
             >
               <span className="flex-1 truncate">{attachment.fileName}</span>
               {attachment.fileSize !== null && attachment.fileSize !== undefined && (
@@ -45,7 +45,7 @@ export function AttachmentList({ attachments }: AttachmentListProps) {
               href={attachment.url ?? '#'}
               target="_blank"
               rel="noreferrer"
-              className="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-blue underline typo-pc-b3 transition-colors hover:bg-gray-400"
+              className="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-blue underline typo-pc-b3 mobile:typo-m-b3 transition-colors hover:bg-gray-400"
             >
               {attachment.url}
             </a>

--- a/src/components/board/AttachmentUploader.tsx
+++ b/src/components/board/AttachmentUploader.tsx
@@ -124,7 +124,7 @@ export function AttachmentUploader({
         {attachments.map((draft) => (
           <Reorder.Item key={draft.id} value={draft}>
             {draft.status === 'error' ? (
-              <div className="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-red typo-pc-b3">
+              <div className="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-red typo-pc-b3 mobile:typo-m-b3">
                 <span className="flex-1 truncate">
                   {draft.fileName ?? draft.url} — {draft.errorMessage}
                 </span>
@@ -173,13 +173,13 @@ export function AttachmentUploader({
           type="button"
           onClick={handleAddLink}
           disabled={isFull}
-          className="whitespace-nowrap typo-pc-b3 text-white underline"
+          className="whitespace-nowrap typo-pc-b3 mobile:typo-m-b3 text-white underline"
         >
           링크 추가
         </button>
       </div>
       {isFull && (
-        <p className="typo-pc-c1 text-gray-500">첨부는 최대 {maxCount}개까지 등록할 수 있습니다.</p>
+        <p className="typo-pc-c1 mobile:typo-m-c1 text-gray-500">첨부는 최대 {maxCount}개까지 등록할 수 있습니다.</p>
       )}
     </div>
   )

--- a/src/components/board/AttachmentUploader.tsx
+++ b/src/components/board/AttachmentUploader.tsx
@@ -48,6 +48,7 @@ export function AttachmentUploader({
   const [linkInput, setLinkInput] = useState('')
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const isFull = attachments.length >= maxCount
+  const hasPendingLink = linkInput.trim().length > 0
 
   const updateDraft = useCallback(
     (id: string, patch: Partial<AttachmentDraft>) => {
@@ -150,15 +151,21 @@ export function AttachmentUploader({
         ))}
       </Reorder.Group>
 
-      <div className="flex items-center gap-2">
-        <input ref={fileInputRef} type="file" className="hidden" onChange={handleFileSelect} />
-        <GdgUploadButton
-          label="+ 파일 선택"
-          disabled={isFull}
-          onClick={() => fileInputRef.current?.click()}
-        />
+      <input ref={fileInputRef} type="file" className="hidden" onChange={handleFileSelect} />
+
+      {/* GdgUploadButton 은 전폭 CTA 라 폭 옵션이 device 밖에 없다(pc 550px / mobile 343px).
+          입력칸과 같은 flex 행에 두면 눌려서 54px 까지 줄고 '+ 파일 선택' 이 세로로 쪼개져
+          잘린다. 설계대로 자체 행에 둔다. */}
+      <GdgUploadButton
+        label="+ 파일 선택"
+        disabled={isFull}
+        onClick={() => fileInputRef.current?.click()}
+      />
+
+      <div className="flex w-full items-center gap-2">
         <GdgInputField
-          placeholder="https://... 링크 추가"
+          fullWidth
+          placeholder="https://"
           value={linkInput}
           onChange={(event) => setLinkInput(event.target.value)}
           onKeyDown={(event) => {
@@ -173,13 +180,24 @@ export function AttachmentUploader({
           type="button"
           onClick={handleAddLink}
           disabled={isFull}
-          className="whitespace-nowrap typo-pc-b3 mobile:typo-m-b3 text-white underline"
+          className="shrink-0 whitespace-nowrap text-white underline typo-pc-b3 mobile:typo-m-b3"
         >
           링크 추가
         </button>
       </div>
+
+      {/* 입력만 하고 등록하면 그 URL 은 아무 데도 저장되지 않는다. 조용히 사라지는 대신
+          알려준다 — 실제로 이걸 모르고 첨부가 안 됐다는 보고가 있었다. */}
+      {hasPendingLink && (
+        <p className="text-red typo-pc-c1 mobile:typo-m-c1">
+          입력한 링크는 아직 첨부되지 않았습니다. &lsquo;링크 추가&rsquo;를 눌러 주세요.
+        </p>
+      )}
+
       {isFull && (
-        <p className="typo-pc-c1 mobile:typo-m-c1 text-gray-500">첨부는 최대 {maxCount}개까지 등록할 수 있습니다.</p>
+        <p className="text-gray-500 typo-pc-c1 mobile:typo-m-c1">
+          첨부는 최대 {maxCount}개까지 등록할 수 있습니다.
+        </p>
       )}
     </div>
   )

--- a/src/components/board/BoardList.tsx
+++ b/src/components/board/BoardList.tsx
@@ -8,6 +8,11 @@ export interface BoardListColumn<T> {
   header: string
   render: (item: T) => ReactNode
   className?: string
+  /**
+   * 모바일 카드에서 제목 자리에 크게 나올 열. 지정하지 않으면 첫 열을 쓴다.
+   * 게시판마다 첫 열이 제목이 아니다 — 공지는 첫 열이 분류 태그다.
+   */
+  primary?: boolean
 }
 
 export interface BoardListProps<T> {
@@ -26,43 +31,76 @@ export function BoardList<T>({
   emptyMessage = '등록된 글이 없습니다.'
 }: BoardListProps<T>) {
   if (items.length === 0) {
-    return <p className="py-16 text-center text-gray-500 typo-pc-b2">{emptyMessage}</p>
+    return (
+      <p className="py-16 text-center text-gray-500 typo-pc-b2 mobile:typo-m-b2">{emptyMessage}</p>
+    )
   }
 
+  const primaryColumn = columns.find((column) => column.primary) ?? columns[0]
+  const metaColumns = columns.filter((column) => column !== primaryColumn)
+
   return (
-    // 좁은 화면에서 카드 레이아웃으로 바꿀지는 설계 문서 §11이 "구현 중 판단"으로
-    // 남겨뒀다. 지금은 테이블을 유지하되, 가로 스크롤 컨테이너로 감싸 모바일에서
-    // 페이지 전체가 옆으로 밀리는 것만 막는다.
-    <div className="w-full overflow-x-auto">
-      <table className="w-full min-w-[640px] border-collapse text-left text-white">
-        <thead>
-          <tr className="border-b border-gray-800 typo-pc-s3">
-            {columns.map((column) => (
-              <th key={column.key} className={cn('px-4 py-3', column.className)}>
-                {column.header}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((item) => (
-            <tr
-              key={getRowKey(item)}
-              onClick={() => onRowClick?.(item)}
-              className={cn(
-                'border-b border-gray-100 typo-pc-b3',
-                onRowClick && 'cursor-pointer hover:bg-gray-100'
-              )}
-            >
+    <>
+      {/* PC: 표 */}
+      <div className="hidden w-full overflow-x-auto pc:block">
+        <table className="w-full min-w-[640px] border-collapse text-left text-white">
+          <thead>
+            <tr className="border-b border-gray-800 typo-pc-s3">
               {columns.map((column) => (
-                <td key={column.key} className={cn('px-4 py-3', column.className)}>
-                  {column.render(item)}
-                </td>
+                <th key={column.key} className={cn('px-4 py-3', column.className)}>
+                  {column.header}
+                </th>
               ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+          </thead>
+          <tbody>
+            {items.map((item) => (
+              <tr
+                key={getRowKey(item)}
+                onClick={() => onRowClick?.(item)}
+                className={cn(
+                  'border-b border-gray-100 typo-pc-b3',
+                  onRowClick && 'cursor-pointer hover:bg-gray-100'
+                )}
+              >
+                {columns.map((column) => (
+                  <td key={column.key} className={cn('px-4 py-3', column.className)}>
+                    {column.render(item)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* 모바일: 카드.
+          표를 가로 스크롤 컨테이너에 넣어두면 640px 최소폭 때문에 열이 화면 밖으로
+          밀리고, 옆으로 밀 때 머리글과 값이 어긋나 보인다. 좁은 화면에서는 한 행을
+          카드 하나로 세워서 가로 스크롤 자체를 없앤다. */}
+      <ul className="flex w-full flex-col gap-3 pc:hidden">
+        {items.map((item) => (
+          <li key={getRowKey(item)}>
+            <div
+              onClick={() => onRowClick?.(item)}
+              className={cn(
+                'w-full rounded-xl border border-gray-200 px-4 py-3',
+                onRowClick && 'cursor-pointer active:bg-gray-100'
+              )}
+            >
+              <p className="text-white typo-m-s3">{primaryColumn.render(item)}</p>
+              <dl className="mt-2 flex flex-col gap-1 typo-m-c1">
+                {metaColumns.map((column) => (
+                  <div key={column.key} className="flex items-start gap-2">
+                    <dt className="w-14 shrink-0 text-gray-600">{column.header}</dt>
+                    <dd className="min-w-0 flex-1 text-gray-800">{column.render(item)}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </>
   )
 }

--- a/src/components/board/BoardList.tsx
+++ b/src/components/board/BoardList.tsx
@@ -45,7 +45,7 @@ export function BoardList<T>({
       <div className="hidden w-full overflow-x-auto pc:block">
         <table className="w-full min-w-[640px] border-collapse text-left text-white">
           <thead>
-            <tr className="border-b border-gray-800 typo-pc-s3">
+            <tr className="border-b border-gray-800 typo-pc-s3 mobile:typo-m-s3">
               {columns.map((column) => (
                 <th key={column.key} className={cn('px-4 py-3', column.className)}>
                   {column.header}
@@ -59,7 +59,7 @@ export function BoardList<T>({
                 key={getRowKey(item)}
                 onClick={() => onRowClick?.(item)}
                 className={cn(
-                  'border-b border-gray-100 typo-pc-b3',
+                  'border-b border-gray-100 typo-pc-b3 mobile:typo-m-b3',
                   onRowClick && 'cursor-pointer hover:bg-gray-100'
                 )}
               >

--- a/src/components/board/BoardPagination.tsx
+++ b/src/components/board/BoardPagination.tsx
@@ -14,7 +14,9 @@ export function BoardPagination({ page, totalPages, onPageChange }: BoardPaginat
   const pageNumbers = Array.from({ length: totalPages }, (_, index) => index)
 
   return (
-    <nav className="flex w-full items-center justify-center gap-2 py-6">
+    // 페이지 번호를 전부 그린다. 줄바꿈을 막으면 페이지가 늘어날수록 가로로 넘친다.
+    // 글이 쌓여 번호가 너무 많아지면 현재 페이지 주변만 보여주는 방식으로 좁혀야 한다.
+    <nav className="flex w-full flex-wrap items-center justify-center gap-2 py-6">
       <button
         type="button"
         onClick={() => onPageChange(page - 1)}
@@ -31,7 +33,7 @@ export function BoardPagination({ page, totalPages, onPageChange }: BoardPaginat
           onClick={() => onPageChange(number)}
           aria-current={number === page ? 'page' : undefined}
           className={cn(
-            'flex size-8 items-center justify-center rounded-full typo-pc-b3',
+            'flex size-8 items-center justify-center rounded-full typo-pc-b3 mobile:typo-m-b3',
             number === page ? 'bg-red text-white' : 'text-gray-500 hover:text-white'
           )}
         >

--- a/src/components/board/BoardSearchBar.tsx
+++ b/src/components/board/BoardSearchBar.tsx
@@ -21,14 +21,28 @@ export function BoardSearchBar({
   onKeywordChange,
   onSubmit
 }: BoardSearchBarProps) {
-  return (
-    <div className="flex w-full items-center gap-2">
+  /**
+   * device 는 CSS 가 아니라 prop 으로 갈린다. 기본값 'pc' 를 그대로 두면
+   * GdgSearchField 가 w-280(=1120px) 고정폭이라 좁은 화면을 그대로 넘어간다.
+   * 리포 관례대로 pc/mobile 을 각각 렌더하고 CSS 로 감춘다 (login/page.tsx 참고).
+   * 값과 핸들러가 같으니 두 벌이 떠 있어도 상태는 하나다.
+   */
+  const controls = (device: 'pc' | 'mobile') => (
+    <>
       <GdgDropdown
+        device={device}
         options={searchTypeOptions}
         value={searchType}
         onChange={(value) => onSearchTypeChange(value as BoardSearchType)}
       />
       <GdgSearchField
+        device={device}
+        /**
+         * 모바일 full 은 w-85.75(343px)로 고정이라 드롭다운(109px)과 한 줄에 못 넣는다.
+         * twoThirds(226px) + 드롭다운 + 간격 = 343px 로, mobile:px-4 컨테이너의
+         * 가용 폭(375px 화면 기준 343px) 안에 정확히 들어간다.
+         */
+        width={device === 'pc' ? 'full' : 'twoThirds'}
         value={keyword}
         onChange={(event) => onKeywordChange(event.target.value)}
         onKeyDown={(event) => {
@@ -39,6 +53,13 @@ export function BoardSearchBar({
         }}
         placeholder="검색어를 입력하세요"
       />
-    </div>
+    </>
+  )
+
+  return (
+    <>
+      <div className="hidden w-full items-center gap-2 pc:flex">{controls('pc')}</div>
+      <div className="flex w-full min-w-0 items-center gap-2 pc:hidden">{controls('mobile')}</div>
+    </>
   )
 }

--- a/src/components/board/BoardSearchBar.tsx
+++ b/src/components/board/BoardSearchBar.tsx
@@ -22,15 +22,19 @@ export function BoardSearchBar({
   onSubmit
 }: BoardSearchBarProps) {
   /**
-   * device 는 CSS 가 아니라 prop 으로 갈린다. 기본값 'pc' 를 그대로 두면
-   * GdgSearchField 가 w-280(=1120px) 고정폭이라 좁은 화면을 그대로 넘어간다.
-   * 리포 관례대로 pc/mobile 을 각각 렌더하고 CSS 로 감춘다 (login/page.tsx 참고).
-   * 값과 핸들러가 같으니 두 벌이 떠 있어도 상태는 하나다.
+   * 디자인 시스템 컨트롤의 크기는 CSS 가 아니라 device·size prop 으로 정해진다.
+   * 기본값(device='pc', size='small')을 그대로 두면
+   *   - 검색 필드가 w-280(1120px) 고정이라 컨테이너 가용폭 1072px 를 넘고
+   *   - 드롭다운이 w-30.5(122px) 라 '제목+내용' 이 잘린다.
+   * 그래서 device 와 size 를 명시하고, pc/mobile 을 각각 렌더해 CSS 로 감춘다
+   * (login/page.tsx 의 기존 관례). 값과 핸들러가 같아 두 벌이 떠 있어도 상태는 하나다.
    */
   const controls = (device: 'pc' | 'mobile') => (
     <>
       <GdgDropdown
         device={device}
+        // small(pc 122px / mobile 109px)은 '제목+내용'을 담지 못한다.
+        size="medium"
         options={searchTypeOptions}
         value={searchType}
         onChange={(value) => onSearchTypeChange(value as BoardSearchType)}
@@ -38,11 +42,11 @@ export function BoardSearchBar({
       <GdgSearchField
         device={device}
         /**
-         * 모바일 full 은 w-85.75(343px)로 고정이라 드롭다운(109px)과 한 줄에 못 넣는다.
-         * twoThirds(226px) + 드롭다운 + 간격 = 343px 로, mobile:px-4 컨테이너의
-         * 가용 폭(375px 화면 기준 343px) 안에 정확히 들어간다.
+         * pc: half(412px) + 드롭다운(265px) + 간격 = 685px 로 가용폭 1072px 안에 든다.
+         *     full 은 1120px 고정이라 혼자 한 줄을 쓸 때만 맞는 값이다.
+         * mobile: 아래에서 세로로 쌓으므로 full(343px)이 가용폭 358px 에 들어간다.
          */
-        width={device === 'pc' ? 'full' : 'twoThirds'}
+        width={device === 'pc' ? 'half' : 'full'}
         value={keyword}
         onChange={(event) => onKeywordChange(event.target.value)}
         onKeyDown={(event) => {
@@ -59,7 +63,10 @@ export function BoardSearchBar({
   return (
     <>
       <div className="hidden w-full items-center gap-2 pc:flex">{controls('pc')}</div>
-      <div className="flex w-full min-w-0 items-center gap-2 pc:hidden">{controls('mobile')}</div>
+      {/* 모바일은 한 줄에 못 넣는다. 드롭다운(168px)+검색(343px)이 가용폭 358px 를 넘는다. */}
+      <div className="flex w-full min-w-0 flex-col items-stretch gap-2 pc:hidden">
+        {controls('mobile')}
+      </div>
     </>
   )
 }

--- a/src/components/board/PinnedNoticeModal.tsx
+++ b/src/components/board/PinnedNoticeModal.tsx
@@ -132,20 +132,20 @@ export function PinnedNoticeModal({ open, apiClient, onClose, onSaved }: PinnedN
     >
       <div className="flex max-h-[85vh] w-full max-w-[640px] flex-col gap-4 overflow-y-auto rounded-2xl border border-gray-800 bg-black p-6 text-white">
         <div className="flex items-center justify-between">
-          <h2 className="typo-pc-s2">상단 고정 관리</h2>
+          <h2 className="typo-pc-s2 mobile:typo-m-s2">상단 고정 관리</h2>
           <button type="button" onClick={onClose} className="text-gray-500 hover:text-white">
             닫기
           </button>
         </div>
 
         <section className="flex flex-col gap-2">
-          <p className="text-gray-500 typo-pc-c1">
+          <p className="text-gray-500 typo-pc-c1 mobile:typo-m-c1">
             현재 고정 {selected.length}/{MAX_PINNED} — 드래그해 순서를 바꿉니다.
           </p>
           {loading ? (
-            <p className="py-6 text-center text-gray-500 typo-pc-b3">불러오는 중...</p>
+            <p className="py-6 text-center text-gray-500 typo-pc-b3 mobile:typo-m-b3">불러오는 중...</p>
           ) : selected.length === 0 ? (
-            <p className="py-6 text-center text-gray-500 typo-pc-b3">고정된 공지가 없습니다.</p>
+            <p className="py-6 text-center text-gray-500 typo-pc-b3 mobile:typo-m-b3">고정된 공지가 없습니다.</p>
           ) : (
             <Reorder.Group
               axis="y"
@@ -155,7 +155,7 @@ export function PinnedNoticeModal({ open, apiClient, onClose, onSaved }: PinnedN
             >
               {selected.map((notice, index) => (
                 <Reorder.Item key={notice.id} value={notice}>
-                  <div className="flex cursor-grab items-center gap-3 rounded-lg bg-gray-100 px-4 py-2 typo-pc-b3">
+                  <div className="flex cursor-grab items-center gap-3 rounded-lg bg-gray-100 px-4 py-2 typo-pc-b3 mobile:typo-m-b3">
                     <span className="shrink-0 text-gray-700">{index + 1}</span>
                     <NoticeCategoryTag category={notice.category} />
                     <span className="flex-1 truncate">{notice.title}</span>
@@ -174,27 +174,37 @@ export function PinnedNoticeModal({ open, apiClient, onClose, onSaved }: PinnedN
         </section>
 
         <section className="flex flex-col gap-2 border-t border-gray-800 pt-4">
-          <p className="text-gray-500 typo-pc-c1">
+          <p className="text-gray-500 typo-pc-c1 mobile:typo-m-c1">
             고정할 공지 찾기 (공개된 공지만 고정할 수 있습니다)
           </p>
-          <GdgSearchField
-            value={keyword}
-            onChange={(event) => setKeyword(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                event.preventDefault()
-                setSubmittedKeyword(keyword)
-              }
-            }}
-            placeholder="제목·내용으로 검색"
-          />
+          {/* device 기본값 'pc' 는 w-280(=1120px) 고정폭이라 640px 모달을 넘긴다.
+              좁은 화면에서는 더 심하다. pc/mobile 을 각각 렌더하고 CSS 로 감춘다. */}
+          {(['pc', 'mobile'] as const).map((device) => (
+            <GdgSearchField
+              key={device}
+              device={device}
+              // pc 는 half(412px)면 640px 모달에 들어간다. mobile 은 half 가 w-fit 으로
+              // 떨어져 입력칸이 글자 폭만큼 쪼그라들므로 full(343px)을 쓴다.
+              width={device === 'pc' ? 'half' : 'full'}
+              className={device === 'pc' ? 'hidden pc:flex' : 'flex pc:hidden'}
+              value={keyword}
+              onChange={(event) => setKeyword(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault()
+                  setSubmittedKeyword(keyword)
+                }
+              }}
+              placeholder="제목·내용으로 검색"
+            />
+          ))}
           <ul className="flex flex-col gap-1">
             {candidates.map((notice) => {
               const alreadySelected = selected.some((item) => item.id === notice.id)
               return (
                 <li
                   key={notice.id}
-                  className="flex items-center gap-3 border-b border-gray-800 px-1 py-2 typo-pc-b3"
+                  className="flex items-center gap-3 border-b border-gray-800 px-1 py-2 typo-pc-b3 mobile:typo-m-b3"
                 >
                   <NoticeCategoryTag category={notice.category} />
                   <span className="flex-1 truncate">{notice.title}</span>
@@ -210,17 +220,17 @@ export function PinnedNoticeModal({ open, apiClient, onClose, onSaved }: PinnedN
               )
             })}
             {candidates.length === 0 && (
-              <li className="py-4 text-center text-gray-500 typo-pc-c1">검색 결과가 없습니다.</li>
+              <li className="py-4 text-center text-gray-500 typo-pc-c1 mobile:typo-m-c1">검색 결과가 없습니다.</li>
             )}
           </ul>
           {isFull && (
-            <p className="text-gray-500 typo-pc-c1">
+            <p className="text-gray-500 typo-pc-c1 mobile:typo-m-c1">
               슬롯이 가득 찼습니다. 추가하려면 먼저 하나를 빼세요.
             </p>
           )}
         </section>
 
-        {errorMessage && <p className="text-red typo-pc-b3">{errorMessage}</p>}
+        {errorMessage && <p className="text-red typo-pc-b3 mobile:typo-m-b3">{errorMessage}</p>}
 
         <div className="flex gap-3">
           <GdgButton variant="bordered" fullWidth onClick={onClose}>

--- a/src/components/board/boardMenus.ts
+++ b/src/components/board/boardMenus.ts
@@ -1,0 +1,13 @@
+import type { GdgMenuLink } from '@/components/ui/design-system'
+
+/**
+ * 게시판 페이지들이 공유하는 헤더 메뉴.
+ *
+ * 페이지마다 자기 게시판만 넣어두면 다른 게시판으로 갈 수단이 사라진다 —
+ * 실제로 공지 게시판에서 행사 게시판으로 이동할 방법이 없었다.
+ * 게시판이 늘어날 때 여기 한 곳만 고치면 8개 페이지가 함께 맞는다.
+ */
+export const BOARD_MENUS: GdgMenuLink[] = [
+  { label: '행사', url: '/board/events/' },
+  { label: '공지사항', url: '/board/notices/' }
+]

--- a/src/components/landing/OnboardingLanding.tsx
+++ b/src/components/landing/OnboardingLanding.tsx
@@ -369,10 +369,11 @@ function SiteHeader({
             마이페이지 항목은 화면에 나오지 않는다. 게시판 링크도 같은 이유로
             여기 둔다 — 드로어의 게시판 항목만으로는 모바일에서 도달할 수 없다. */}
         <div className="flex items-center gap-4 justify-self-end">
-          {/* 게시판이 둘(행사·공지)이지만 헤더 링크는 하나로 두고 공지를 가리킨다.
-              행사 게시판(/board/events/)은 헤더에서 도달할 수 없다 — 의도된 선택이다. */}
+          {/* 랜딩은 비로그인 방문자가 보는 화면이라 공개 게시판인 행사로 보낸다.
+              공지는 로그인이 필요해서 여기서 링크하면 바로 로그인으로 튕긴다.
+              게시판끼리의 이동은 게시판 헤더의 BOARD_MENUS 가 담당한다. */}
           <a
-            href="/board/notices/"
+            href="/board/events/"
             className="typo-pc-b2 text-gray-500 transition-colors hover:text-white"
           >
             게시판
@@ -418,7 +419,7 @@ function MobileMenuDrawer({
     { label: '소개', action: () => onNavigate('about') },
     { label: '활동', action: () => onNavigate('activities') },
     { label: 'FAQ', action: () => onNavigate('faq') },
-    { label: '게시판', href: '/board/notices/' },
+    { label: '게시판', href: '/board/events/' },
     { label: '마이페이지', href: '/profile' },
     ...(canSeeDashboard ? [{ label: '대시보드', href: '/dashboard' }] : [])
   ]

--- a/src/services/board/noticeClient.ts
+++ b/src/services/board/noticeClient.ts
@@ -1,6 +1,5 @@
 import type { AxiosInstance } from 'axios'
 
-import { publicClient } from '@/lib/api/publicClient'
 import type {
   NoticeCreatePayload,
   NoticeDetail,
@@ -43,13 +42,16 @@ interface NoticeListBody {
 }
 
 /**
- * client 기본값이 publicClient인 이유: 비로그인 방문자가 apiClient의 401 인터셉터에
- * 걸려 /login으로 튕기는 것을 막는다. 반대로 CORE 이상은 apiClient를 넘겨야
- * 자기 임시저장(isPublished=false)이 목록에 보인다 — 서버가 역할로 거른다.
+ * 공지는 로그인한 사용자만 볼 수 있다. 그래서 client를 필수로 받는다 —
+ * 기본값을 publicClient로 두면 토큰 없이 조회가 나가고, 서버가 permitAll을
+ * 걷어내는 순간 조용히 401이 된다. 호출 전에 로그인 여부를 가르는 건 화면의 몫이다.
+ *
+ * CORE 이상이 자기 임시저장(isPublished=false)까지 보려면 토큰이 실려야 한다 —
+ * 서버가 역할로 거른다.
  */
 export const fetchNoticeList = async (
-  params: FetchNoticeListParams = {},
-  client: AxiosInstance = publicClient
+  params: FetchNoticeListParams,
+  client: AxiosInstance
 ): Promise<NoticeListResult> => {
   const response = await client.get('/board/notices', {
     params: {
@@ -65,7 +67,7 @@ export const fetchNoticeList = async (
 
 export const fetchNoticeDetail = async (
   id: number,
-  client: AxiosInstance = publicClient
+  client: AxiosInstance
 ): Promise<NoticeDetail> => {
   const response = await client.get(`/board/notices/${id}`)
   return unwrapOnce<NoticeDetail>(response.data)


### PR DESCRIPTION
## #️⃣ Related Issue
> 없음 (배포본 확인 중 발견)

## 📝 PR Description

행사·공지 게시판 배포 후 사용자가 보고한 문제들을 고친다. 다섯 가지이고,
뒤의 세 가지는 원인이 같다.

### 1. 다른 게시판으로 갈 수단이 없었다

각 게시판 페이지가 `GdgSiteHeader` 에 자기 메뉴만 넘기고 있었다. 공지에 들어가면
행사로 갈 방법이 아예 없었다. `BOARD_MENUS` 로 묶어 8개 페이지가 같은 메뉴를 쓴다.

온보딩 랜딩의 '게시판' 링크는 행사로 돌린다. 랜딩은 비로그인 방문자가 보는 화면인데
공지는 회원 전용이라, 공지를 걸면 곧바로 로그인으로 튕긴다.

### 2. 공지가 비로그인에게도 열려 있었다

공지 목록·상세가 `publicClient` 로 나가 토큰이 붙지 않았다. 비로그인은 로그인으로
보내고, 로그인 상태면 항상 `apiClient` 를 쓴다. `fetchNoticeList`/`fetchNoticeDetail` 의
`client` 를 필수 인자로 바꿔 토큰 없는 호출이 타입에서 걸리게 했다.

> ⚠️ **이것만으로는 강제되지 않는다.** 서버 `SecurityConfig` 에
> `/api/v1/board/notices` GET `permitAll` 이 남아 있어 API 를 직접 부르면 여전히 열린다.
> 서버에서 그 두 줄을 빼야 완결된다.

### 3. 좁은 화면에서 목록이 옆으로 밀렸다

`BoardList` 가 `min-w-[640px]` 표를 가로 스크롤 컨테이너에 넣고 있었다. 390px 화면에서
열이 화면 밖으로 나가고, 옆으로 밀면 머리글과 값이 어긋나 보인다. PC 는 표를 그대로 두고
좁은 화면에서만 한 행을 카드로 세운다. 카드 제목은 새 `primary` 플래그로 고른다 —
게시판마다 첫 열이 제목이 아니다(공지는 분류 태그다).

### 4~5. 고정폭 컨트롤이 잘리거나 넘쳤다

**디자인 시스템 컨트롤의 크기는 CSS 가 아니라 `device`·`size` prop 으로 정해진다.**
기본값(`device='pc'`, `size='small'`)을 그대로 쓴 탓에 컨테이너 폭과 어긋났다.

| 증상 | 원인 | 수정 |
|---|---|---|
| 검색바가 표·버튼보다 오른쪽으로 튀어나옴 | 검색 필드 `w-280`(1120px) + 드롭다운이 가용폭 1072px 를 **178px 초과** | pc `half`(412px), 모바일 세로 배치 |
| '제목+내용'·'분류를 선택하세요'가 잘림 | 드롭다운 기본 `size=small` = **122px** | `medium`(pc 265px / mobile 168px) |
| '+ 파일 선택'이 세로로 쪼개져 잘림 | `GdgUploadButton` 은 폭 옵션이 `device` 밖에 없는 전폭 CTA(550px)인데 입력칸과 같은 flex 행에 둬서 **54px 로 눌림** | 자체 행으로 분리, 링크 입력칸은 `fullWidth` |
| URL 을 입력해도 첨부가 저장 안 됨 | '링크 추가' 를 누르지 않으면 입력값이 조용히 사라짐 | 미등록 상태를 경고로 표시 |

`typo-pc-*` 86곳에는 `mobile:typo-m-*` 짝을 붙였다. 모바일 계열 이름은
`typo-mobile-*` 이 아니라 `typo-m-*` 이고, 대시보드는 이미 쓰고 있었다.

`BoardPagination` 은 번호를 전부 그리면서 줄바꿈이 없어 가로로 넘쳤다. `flex-wrap` 을 준다.
글이 쌓여 번호가 너무 많아지면 현재 페이지 주변만 보여주는 방식으로 좁혀야 한다.

## 💬 Reviewer Request

**`AttachmentList` 의 `isFileAttachment` 를 지우지 말아주세요.** 서버 응답에 `kind` 가
없을 때 파일 첨부가 링크 분기로 떨어져 빈 `<a>` 가 됩니다.

**`OnboardingLanding` 헤더 컨테이너에 `mobile:hidden` 을 다시 넣지 말아주세요.**
`8f1450f` 에서 "모바일에 진입 수단이 없어지는" 버그로 고친 부분이고, 같은 파일의
`MobileMenuDrawer` 는 렌더되지 않는 죽은 코드라 대체되지 않습니다.

**컨트롤을 추가할 때 `device`·`size` 를 명시해주세요.** 이 PR 문제의 절반이 기본값을
그대로 둬서 생겼습니다. 기본값은 `pc`/`small` 이고 CSS 로 반응하지 않습니다.

## 검증

```
yarn build  → exit 0
yarn lint   → exit 0 · 에러 0건
```

로컬 정적 빌드를 띄워 **실측**했습니다(가용폭 1072px 기준).

| | 수정 전 | 수정 후 |
|---|---|---|
| 검색바 합계 | 1250px (178px 초과) | 685px |
| 모바일 최대 요소 | 1120px | 343px (375px 화면에 맞음) |

**확인하지 못한 것:** 작성 폼은 로컬에서 로그인이 안 돼 CORE 게이트에 막혀 화면으로
보지 못했습니다. 첨부 버튼이 폼 가용폭(672px)에 들어간다는 것은 수치로만 확인했습니다.
카드 레이아웃도 행사 게시글이 0건이라 렌더를 보지 못했습니다. 배포 후 확인이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug7rbkpZ4cgNgECyv1GEXn
