### PR TITLE
feat: 자유게시판 화면

### DIFF
--- a/src/app/board/free/detail/page.tsx
+++ b/src/app/board/free/detail/page.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import axios from 'axios'
+import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useCallback, useEffect, useState } from 'react'
+
+import { AttachmentList } from '@/components/board/AttachmentList'
+import { BOARD_MENUS } from '@/components/board/boardMenus'
+import { GdgSiteHeader } from '@/components/ui/design-system'
+import { useAuth } from '@/hooks/useAuth'
+import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
+import { deleteFreePost, fetchFreeDetail } from '@/services/board/freeClient'
+import type { FreeBoardDetail } from '@/types/free'
+import { hasAtLeast } from '@/utils/auth/role'
+import { formatDate } from '@/utils/formatDate'
+
+export default function FreeBoardDetailPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { user } = useAuth()
+  const { apiClient } = useAuthenticatedApi()
+
+  const idParam = searchParams.get('id')
+  const id = idParam ? Number(idParam) : NaN
+
+  const [detail, setDetail] = useState<FreeBoardDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  // 회원 전용이다. 목록과 같은 게이트를 상세에도 건다 — 링크로 직접 들어올 수 있다.
+  const isLoggedIn = Boolean(user)
+
+  /**
+   * 서버 규칙(FreeBoardService.requireAuthorOrOrganizer)과 같은 조건이다.
+   * 상세 응답이 authorId를 주므로 행사·공지처럼 넓게 보여주고 403에 맡기지 않아도 된다.
+   */
+  const canManage =
+    detail !== null &&
+    (hasAtLeast(user?.userRole, 'ORGANIZER') ||
+      (user?.id !== undefined && user.id === detail.authorId))
+
+  useEffect(() => {
+    if (isLoggedIn) return
+    router.replace(
+      `/login?next=${encodeURIComponent(idParam ? `/board/free/detail/?id=${idParam}` : '/board/free/')}`
+    )
+  }, [idParam, isLoggedIn, router])
+
+  useEffect(() => {
+    if (!isLoggedIn) return
+
+    if (!Number.isFinite(id)) {
+      setLoading(false)
+      setError('잘못된 접근입니다.')
+      return
+    }
+
+    let alive = true
+    setLoading(true)
+    setError(null)
+    setNotFound(false)
+
+    fetchFreeDetail(id, apiClient)
+      .then((data) => {
+        if (alive) setDetail(data)
+      })
+      .catch((err) => {
+        if (!alive) return
+        if (axios.isAxiosError(err) && err.response?.status === 404) {
+          setNotFound(true)
+        } else {
+          setError('글을 불러오지 못했습니다.')
+        }
+      })
+      .finally(() => {
+        if (alive) setLoading(false)
+      })
+
+    return () => {
+      alive = false
+    }
+  }, [apiClient, id, isLoggedIn])
+
+  const handleDelete = useCallback(async () => {
+    if (!Number.isFinite(id)) return
+    if (!window.confirm('정말 삭제하시겠습니까?')) return
+
+    setDeleting(true)
+    try {
+      await deleteFreePost(apiClient, id)
+      router.push('/board/free/')
+    } catch {
+      alert('삭제에 실패했습니다.')
+    } finally {
+      setDeleting(false)
+    }
+  }, [apiClient, id, router])
+
+  // 로그인으로 보내는 사이 그려지는 한 프레임. "불러오는 중"으로 두면 실패로 오해한다.
+  if (!isLoggedIn) {
+    return (
+      <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
+        <p className="typo-pc-b2 mobile:typo-m-b2">로그인이 필요한 게시판입니다.</p>
+      </main>
+    )
+  }
+
+  if (loading) {
+    return (
+      <p className="py-16 text-center text-white typo-pc-b2 mobile:typo-m-b2">불러오는 중...</p>
+    )
+  }
+
+  if (notFound) {
+    return (
+      <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
+        <p className="typo-pc-b2 mobile:typo-m-b2">삭제되었거나 존재하지 않는 글입니다.</p>
+        <Link href="/board/free/" className="mt-4 inline-block underline typo-pc-b3 mobile:typo-m-b3">
+          목록으로
+        </Link>
+      </main>
+    )
+  }
+
+  if (error || !detail) {
+    return (
+      <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
+        <p className="text-red typo-pc-b2 mobile:typo-m-b2">
+          {error ?? '글을 불러오지 못했습니다.'}
+        </p>
+        <Link href="/board/free/" className="mt-4 inline-block underline typo-pc-b3 mobile:typo-m-b3">
+          목록으로
+        </Link>
+      </main>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-black text-white">
+      <GdgSiteHeader menus={BOARD_MENUS} actionMenu={{ label: '내 정보', url: '/profile/' }} />
+      <div className="mx-auto w-full max-w-[880px] space-y-6 px-6 mobile:px-4 py-10">
+        <Link
+          href="/board/free/"
+          className="text-gray-700 typo-pc-c2 mobile:typo-m-c2 hover:text-white"
+        >
+          목록으로
+        </Link>
+
+        <div className="space-y-2">
+          <h1 className="typo-pc-h3 mobile:typo-m-h2">{detail.title}</h1>
+          <div className="flex flex-wrap gap-4 text-gray-500 typo-pc-c1 mobile:typo-m-c1">
+            <span>{detail.authorName}</span>
+            <span>{formatDate(detail.createdAt)}</span>
+            {/* 조회수는 서버가 상세 조회마다 +1 한다. 이 값은 이번 조회가 반영된 뒤의 수치다. */}
+            <span>조회 {detail.viewCount}</span>
+          </div>
+        </div>
+
+        <p className="whitespace-pre-wrap typo-pc-b2 mobile:typo-m-b2">{detail.content}</p>
+
+        <AttachmentList attachments={detail.attachments} />
+
+        {canManage && (
+          <div className="flex gap-3 border-t border-gray-800 pt-6">
+            <Link
+              href={`/board/free/edit?id=${detail.id}`}
+              className="rounded-full border border-gray-800 px-6 py-2 typo-pc-b3 mobile:typo-m-b3"
+            >
+              수정
+            </Link>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleting}
+              className="rounded-full border border-red px-6 py-2 text-red typo-pc-b3 mobile:typo-m-b3 disabled:opacity-50"
+            >
+              삭제
+            </button>
+          </div>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/src/app/board/free/edit/page.tsx
+++ b/src/app/board/free/edit/page.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import axios from 'axios'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useCallback, useEffect, useState } from 'react'
+
+import { AttachmentUploader, type AttachmentDraft } from '@/components/board/AttachmentUploader'
+import { BOARD_MENUS } from '@/components/board/boardMenus'
+import {
+  GdgButton,
+  GdgInputField,
+  GdgSiteHeader,
+  GdgTextarea
+} from '@/components/ui/design-system'
+import { useAuth } from '@/hooks/useAuth'
+import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
+import { fetchFreeDetail, updateFreePost } from '@/services/board/freeClient'
+import { hasAtLeast } from '@/utils/auth/role'
+
+const FREE_S3_KEY = 'boardFree'
+
+const createDraftId = (): string =>
+  typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random()}`
+
+export default function FreeBoardEditPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { user } = useAuth()
+  const { apiClient } = useAuthenticatedApi()
+
+  const idParam = searchParams.get('id')
+  const id = idParam ? Number(idParam) : NaN
+
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  // 남의 글이면 서버가 403을 줄 것을 미리 알아내 폼 대신 안내를 띄운다.
+  const [forbidden, setForbidden] = useState(false)
+
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
+  const [attachments, setAttachments] = useState<AttachmentDraft[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const isMember = hasAtLeast(user?.userRole, 'MEMBER')
+
+  useEffect(() => {
+    if (!isMember) return
+    if (!Number.isFinite(id)) {
+      setLoading(false)
+      setLoadError('잘못된 접근입니다.')
+      return
+    }
+
+    let alive = true
+    fetchFreeDetail(id, apiClient)
+      .then((detail) => {
+        if (!alive) return
+
+        // 서버 규칙(FreeBoardService.requireAuthorOrOrganizer)과 같은 조건이다.
+        // 상세 응답이 authorId를 주므로 저장을 눌러 403을 받기 전에 판정할 수 있다.
+        const canManage =
+          hasAtLeast(user?.userRole, 'ORGANIZER') ||
+          (user?.id !== undefined && user.id === detail.authorId)
+        if (!canManage) {
+          setForbidden(true)
+          return
+        }
+
+        setTitle(detail.title)
+        setContent(detail.content)
+        setAttachments(
+          detail.attachments.map((attachment) => ({
+            id: createDraftId(),
+            kind: attachment.kind,
+            fileName: attachment.fileName ?? undefined,
+            fileKey: attachment.fileKey ?? undefined,
+            url: attachment.url ?? undefined,
+            status: 'done' as const
+          }))
+        )
+      })
+      .catch(() => {
+        if (alive) setLoadError('글을 불러오지 못했습니다.')
+      })
+      .finally(() => {
+        if (alive) setLoading(false)
+      })
+
+    return () => {
+      alive = false
+    }
+  }, [apiClient, id, isMember, user?.id, user?.userRole])
+
+  const handleSubmit = useCallback(async () => {
+    if (!Number.isFinite(id)) return
+    if (!title.trim() || !content.trim()) {
+      setErrorMessage('필수 항목을 모두 입력해 주세요.')
+      return
+    }
+
+    setSubmitting(true)
+    setErrorMessage(null)
+
+    try {
+      // 전 필드를 보낸다. attachments는 null이 아니면 서버가 통째로 교체하므로
+      // (FreeBoardService.updatePost) 화면의 최종 상태가 곧 저장 결과다.
+      await updateFreePost(apiClient, id, {
+        title: title.trim(),
+        content,
+        attachments: attachments
+          .filter((item) => item.status === 'done')
+          .map((item) =>
+            item.kind === 'FILE'
+              ? { fileKey: item.fileKey, fileName: item.fileName }
+              : { url: item.url }
+          )
+      })
+      router.push(`/board/free/detail?id=${id}`)
+    } catch (err) {
+      if (axios.isAxiosError(err) && typeof err.response?.data?.message === 'string') {
+        setErrorMessage(err.response.data.message)
+      } else {
+        setErrorMessage('수정에 실패했습니다.')
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }, [apiClient, attachments, content, id, router, title])
+
+  if (!isMember) {
+    return (
+      <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
+        <p className="typo-pc-b2 mobile:typo-m-b2">수정 권한이 없습니다.</p>
+      </main>
+    )
+  }
+
+  if (loading) {
+    return (
+      <p className="py-16 text-center text-white typo-pc-b2 mobile:typo-m-b2">불러오는 중...</p>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
+        <p className="typo-pc-b2 mobile:typo-m-b2">본인이 쓴 글만 수정할 수 있습니다.</p>
+      </main>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
+        <p className="text-red typo-pc-b2 mobile:typo-m-b2">{loadError}</p>
+      </main>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-black text-white">
+      <GdgSiteHeader menus={BOARD_MENUS} actionMenu={{ label: '내 정보', url: '/profile/' }} />
+      <div className="mx-auto w-full max-w-[720px] space-y-6 px-6 mobile:px-4 py-10">
+        <h1 className="typo-pc-h3 mobile:typo-m-h2">자유게시판 수정</h1>
+
+        <GdgInputField
+          label="제목"
+          fullWidth
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+        />
+
+        <GdgTextarea
+          label="내용"
+          fullWidth
+          rows={12}
+          value={content}
+          onChange={(event) => setContent(event.target.value)}
+        />
+
+        <div className="flex flex-col gap-2">
+          <span className="tracking-[0.2em] text-white/80 typo-pc-s3 mobile:typo-m-s3 uppercase">
+            첨부
+          </span>
+          <AttachmentUploader
+            attachments={attachments}
+            onChange={setAttachments}
+            apiClient={apiClient}
+            s3key={FREE_S3_KEY}
+          />
+        </div>
+
+        {errorMessage && <p className="text-red typo-pc-b3 mobile:typo-m-b3">{errorMessage}</p>}
+
+        <GdgButton variant="active" fullWidth onClick={handleSubmit} loading={submitting}>
+          저장
+        </GdgButton>
+      </div>
+    </main>
+  )
+}

--- a/src/app/board/free/new/page.tsx
+++ b/src/app/board/free/new/page.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import axios from 'axios'
+import { useRouter } from 'next/navigation'
+import { useCallback, useState } from 'react'
+
+import { AttachmentUploader, type AttachmentDraft } from '@/components/board/AttachmentUploader'
+import { BOARD_MENUS } from '@/components/board/boardMenus'
+import {
+  GdgButton,
+  GdgInputField,
+  GdgSiteHeader,
+  GdgTextarea
+} from '@/components/ui/design-system'
+import { useAuth } from '@/hooks/useAuth'
+import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
+import { createFreePost } from '@/services/board/freeClient'
+import { hasAtLeast } from '@/utils/auth/role'
+
+// S3KeyType enum의 '이름' 그대로다 (value 'board/free'가 아니다).
+// 요청 DTO의 s3key 필드 타입이 S3KeyType이라 jackson이 enum 이름으로 역직렬화한다.
+const FREE_S3_KEY = 'boardFree'
+
+export default function FreeBoardNewPage() {
+  const router = useRouter()
+  const { user } = useAuth()
+  const { apiClient } = useAuthenticatedApi()
+
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
+  const [attachments, setAttachments] = useState<AttachmentDraft[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const handleSubmit = useCallback(async () => {
+    if (!title.trim() || !content.trim()) {
+      setErrorMessage('필수 항목을 모두 입력해 주세요.')
+      return
+    }
+
+    setSubmitting(true)
+    setErrorMessage(null)
+
+    try {
+      const id = await createFreePost(apiClient, {
+        title: title.trim(),
+        content,
+        attachments: attachments
+          .filter((item) => item.status === 'done')
+          .map((item) =>
+            item.kind === 'FILE'
+              ? { fileKey: item.fileKey, fileName: item.fileName }
+              : { url: item.url }
+          )
+      })
+      router.push(`/board/free/detail?id=${id}`)
+    } catch (err) {
+      if (axios.isAxiosError(err) && typeof err.response?.data?.message === 'string') {
+        setErrorMessage(err.response.data.message)
+      } else {
+        setErrorMessage('등록에 실패했습니다.')
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }, [apiClient, attachments, content, router, title])
+
+  // 공지·행사가 CORE 이상인 것과 다르다. 자유게시판은 회원이면 누구나 쓴다.
+  if (!hasAtLeast(user?.userRole, 'MEMBER')) {
+    return (
+      <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
+        <p className="typo-pc-b2 mobile:typo-m-b2">글쓰기 권한이 없습니다.</p>
+      </main>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-black text-white">
+      <GdgSiteHeader menus={BOARD_MENUS} actionMenu={{ label: '내 정보', url: '/profile/' }} />
+      <div className="mx-auto w-full max-w-[720px] space-y-6 px-6 mobile:px-4 py-10">
+        <h1 className="typo-pc-h3 mobile:typo-m-h2">자유게시판 작성</h1>
+
+        <GdgInputField
+          label="제목"
+          fullWidth
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+        />
+
+        <GdgTextarea
+          label="내용"
+          fullWidth
+          rows={12}
+          value={content}
+          onChange={(event) => setContent(event.target.value)}
+        />
+
+        <div className="flex flex-col gap-2">
+          <span className="tracking-[0.2em] text-white/80 typo-pc-s3 mobile:typo-m-s3 uppercase">
+            첨부
+          </span>
+          <AttachmentUploader
+            attachments={attachments}
+            onChange={setAttachments}
+            apiClient={apiClient}
+            s3key={FREE_S3_KEY}
+          />
+        </div>
+
+        {errorMessage && <p className="text-red typo-pc-b3 mobile:typo-m-b3">{errorMessage}</p>}
+
+        <GdgButton variant="active" fullWidth onClick={handleSubmit} loading={submitting}>
+          등록
+        </GdgButton>
+      </div>
+    </main>
+  )
+}

--- a/src/app/board/free/page.tsx
+++ b/src/app/board/free/page.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useState } from 'react'
+
+import { BoardList, type BoardListColumn } from '@/components/board/BoardList'
+import { BoardPagination } from '@/components/board/BoardPagination'
+import { BoardSearchBar } from '@/components/board/BoardSearchBar'
+import { BOARD_MENUS } from '@/components/board/boardMenus'
+import { GdgSiteHeader } from '@/components/ui/design-system'
+import { useAuth } from '@/hooks/useAuth'
+import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
+import { fetchFreeList } from '@/services/board/freeClient'
+import type { FreeBoardSummary, FreeSearchType } from '@/types/free'
+import type { PageMeta } from '@/utils/api/unwrapPaged'
+import { hasAtLeast } from '@/utils/auth/role'
+import { formatDate } from '@/utils/formatDate'
+
+const SEARCH_TYPE_OPTIONS = [
+  { id: 'TITLE_AND_CONTENT', label: '제목+내용' },
+  { id: 'TITLE', label: '제목' },
+  { id: 'CONTENT', label: '내용' },
+  { id: 'AUTHOR', label: '작성자' }
+]
+
+export default function FreeBoardListPage() {
+  const router = useRouter()
+  const { user } = useAuth()
+  const { apiClient } = useAuthenticatedApi()
+
+  const [page, setPage] = useState(0)
+  const [searchType, setSearchType] = useState<FreeSearchType>('TITLE_AND_CONTENT')
+  const [keyword, setKeyword] = useState('')
+  const [submittedKeyword, setSubmittedKeyword] = useState('')
+  const [items, setItems] = useState<FreeBoardSummary[]>([])
+  const [meta, setMeta] = useState<PageMeta | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // 공지가 CORE 이상인 것과 다르다. 자유게시판은 회원이면 누구나 쓴다.
+  const canWrite = hasAtLeast(user?.userRole, 'MEMBER')
+  // 회원 전용이다. 행사 게시판과 달리 비로그인은 목록조차 볼 수 없다.
+  const isLoggedIn = Boolean(user)
+
+  useEffect(() => {
+    if (isLoggedIn) return
+    router.replace(`/login?next=${encodeURIComponent('/board/free/')}`)
+  }, [isLoggedIn, router])
+
+  useEffect(() => {
+    // 게이트가 로그인으로 보내는 중이다. 여기서 조회하면 토큰 없이 나간다.
+    if (!isLoggedIn) return
+
+    let alive = true
+    setLoading(true)
+    setError(null)
+
+    fetchFreeList({ page, size: 15, searchType, keyword: submittedKeyword }, apiClient)
+      .then((result) => {
+        if (!alive) return
+        setItems(result.items)
+        setMeta(result.meta)
+      })
+      .catch(() => {
+        if (alive) setError('목록을 불러오지 못했습니다.')
+      })
+      .finally(() => {
+        if (alive) setLoading(false)
+      })
+
+    return () => {
+      alive = false
+    }
+  }, [apiClient, isLoggedIn, page, searchType, submittedKeyword])
+
+  const handleSubmitSearch = useCallback(() => {
+    setPage(0)
+    setSubmittedKeyword(keyword)
+  }, [keyword])
+
+  const columns: BoardListColumn<FreeBoardSummary>[] = [
+    { key: 'title', header: '제목', primary: true, render: (item) => item.title },
+    { key: 'author', header: '작성자', render: (item) => item.authorName, className: 'w-32' },
+    { key: 'view', header: '조회', render: (item) => item.viewCount, className: 'w-20' },
+    {
+      key: 'createdAt',
+      header: '작성일',
+      render: (item) => formatDate(item.createdAt),
+      className: 'w-32'
+    }
+  ]
+
+  // 위 useEffect가 로그인으로 보내는 사이 한 프레임이 그려진다. 목록 골격 대신
+  // 안내를 띄워야 "빈 게시판"으로 오해하지 않는다.
+  if (!isLoggedIn) {
+    return (
+      <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
+        <p className="typo-pc-b2 mobile:typo-m-b2">로그인이 필요한 게시판입니다.</p>
+      </main>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-black text-white">
+      <GdgSiteHeader menus={BOARD_MENUS} actionMenu={{ label: '내 정보', url: '/profile/' }} />
+      <div className="mx-auto w-full max-w-[1120px] space-y-6 px-6 mobile:px-4 py-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h1 className="typo-pc-h3 mobile:typo-m-h2">자유게시판</h1>
+          {canWrite && (
+            <Link
+              href="/board/free/new/"
+              className="rounded-full bg-red px-6 py-2 text-white typo-pc-b3 mobile:typo-m-b3"
+            >
+              글쓰기
+            </Link>
+          )}
+        </div>
+
+        <BoardSearchBar
+          searchType={searchType}
+          keyword={keyword}
+          searchTypeOptions={SEARCH_TYPE_OPTIONS}
+          onSearchTypeChange={(type) => {
+            setSearchType(type)
+            setPage(0)
+          }}
+          onKeywordChange={setKeyword}
+          onSubmit={handleSubmitSearch}
+        />
+
+        {error && <p className="text-red typo-pc-b3 mobile:typo-m-b3">{error}</p>}
+
+        {loading && (
+          <p className="py-16 text-center text-gray-500 typo-pc-b2 mobile:typo-m-b2">
+            불러오는 중...
+          </p>
+        )}
+        {/* 실패했을 때는 목록을 그리지 않는다. 빈 배열을 넘기면 "등록된 글이 없습니다."가
+            에러 메시지와 나란히 떠서, 못 불러온 것인지 정말 없는 것인지 구분이 안 된다. */}
+        {!loading && !error && (
+          <BoardList
+            items={items}
+            columns={columns}
+            getRowKey={(item) => item.id}
+            onRowClick={(item) => router.push(`/board/free/detail?id=${item.id}`)}
+            emptyMessage="등록된 글이 없습니다."
+          />
+        )}
+
+        {meta && (
+          <BoardPagination page={meta.page} totalPages={meta.totalPages} onPageChange={setPage} />
+        )}
+      </div>
+    </main>
+  )
+}

--- a/src/components/board/boardMenus.ts
+++ b/src/components/board/boardMenus.ts
@@ -9,5 +9,6 @@ import type { GdgMenuLink } from '@/components/ui/design-system'
  */
 export const BOARD_MENUS: GdgMenuLink[] = [
   { label: '행사', url: '/board/events/' },
-  { label: '공지사항', url: '/board/notices/' }
+  { label: '공지사항', url: '/board/notices/' },
+  { label: '자유게시판', url: '/board/free/' }
 ]

--- a/src/services/board/freeClient.ts
+++ b/src/services/board/freeClient.ts
@@ -1,0 +1,74 @@
+import type { AxiosInstance } from 'axios'
+
+import type {
+  FreeBoardCreatePayload,
+  FreeBoardDetail,
+  FreeBoardSummary,
+  FreeBoardUpdatePayload,
+  FreeSearchType
+} from '@/types/free'
+import { unwrapPaged, type PagedResult } from '@/utils/api/unwrapPaged'
+
+export interface FetchFreeListParams {
+  page?: number
+  size?: number
+  searchType?: FreeSearchType
+  keyword?: string
+}
+
+/**
+ * response.data.data를 한 겹만 벗긴다. 공용 unwrapApiResponse는 쓰지 않는다 —
+ * FreeBoardDetail에 'content'(본문) 필드가 있어서 WRAPPER_KEYS의 'content'와 부딪혀
+ * 객체 대신 본문 문자열만 반환한다 (src/utils/api/unwrap.ts).
+ */
+const unwrapOnce = <T>(payload: unknown): T => (payload as { data: T }).data
+
+/**
+ * 자유게시판은 회원 전용이다. 그래서 client를 필수로 받는다 — 기본값을 publicClient로
+ * 두면 토큰 없이 조회가 나가 401이 된다. 호출 전에 로그인 여부를 가르는 건 화면의 몫이다.
+ *
+ * 목록 봉투는 행사와 같다 ({ data: { content: [...] }, meta }). 공지처럼 고정 글이
+ * 따로 오지 않으므로 unwrapPaged를 그대로 쓴다.
+ */
+export const fetchFreeList = async (
+  params: FetchFreeListParams,
+  client: AxiosInstance
+): Promise<PagedResult<FreeBoardSummary>> => {
+  const response = await client.get('/board/free', {
+    params: {
+      page: params.page ?? 0,
+      size: params.size ?? 15,
+      searchType: params.searchType ?? 'TITLE_AND_CONTENT',
+      keyword: params.keyword || undefined
+    }
+  })
+  return unwrapPaged<FreeBoardSummary>(response.data)
+}
+
+export const fetchFreeDetail = async (
+  id: number,
+  client: AxiosInstance
+): Promise<FreeBoardDetail> => {
+  const response = await client.get(`/board/free/${id}`)
+  return unwrapOnce<FreeBoardDetail>(response.data)
+}
+
+export const createFreePost = async (
+  apiClient: AxiosInstance,
+  payload: FreeBoardCreatePayload
+): Promise<number> => {
+  const response = await apiClient.post('/board/free', payload)
+  return unwrapOnce<number>(response.data)
+}
+
+export const updateFreePost = async (
+  apiClient: AxiosInstance,
+  id: number,
+  payload: FreeBoardUpdatePayload
+): Promise<void> => {
+  await apiClient.patch(`/board/free/${id}`, payload)
+}
+
+export const deleteFreePost = async (apiClient: AxiosInstance, id: number): Promise<void> => {
+  await apiClient.delete(`/board/free/${id}`)
+}

--- a/src/types/free.ts
+++ b/src/types/free.ts
@@ -1,0 +1,40 @@
+import type { AttachmentEntry, AttachmentResponse, BoardSearchType } from '@/types/board'
+
+/**
+ * 백엔드는 board/common/enums/SearchType 하나를 행사·공지·자유가 공유한다(값이 동일).
+ * 별칭끼리 엮지 말고 각자 BoardSearchType 을 직접 가리킨다.
+ */
+export type FreeSearchType = BoardSearchType
+
+export interface FreeBoardSummary {
+  id: number
+  title: string
+  authorName: string
+  viewCount: number
+  createdAt: string
+}
+
+/**
+ * 행사·공지 상세와 달리 authorId 가 있다. 수정·삭제 권한이 '작성자 본인 또는
+ * ORGANIZER 이상'이라, 이 값이 없으면 화면이 본인 여부를 판정할 수 없다.
+ */
+export interface FreeBoardDetail {
+  id: number
+  title: string
+  content: string
+  authorId: number
+  authorName: string
+  viewCount: number
+  attachments: AttachmentResponse[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface FreeBoardCreatePayload {
+  title: string
+  content: string
+  attachments: AttachmentEntry[]
+}
+
+/** FreeBoardUpdateRequest는 전 필드 선택이고 null인 필드는 바꾸지 않는다. */
+export type FreeBoardUpdatePayload = Partial<FreeBoardCreatePayload>


### PR DESCRIPTION
## 무엇

자유게시판 화면 4종. 서버 PR [Server#339](https://github.com/GDGoCINHA/24-2_GDGoC_Server/pull/339) 와 짝이다.

| 경로 | 화면 |
|---|---|
| `/board/free/` | 목록 (검색·페이지네이션) |
| `/board/free/detail?id=` | 상세 |
| `/board/free/new/` | 작성 |
| `/board/free/edit?id=` | 수정 |

헤더 메뉴(`BOARD_MENUS`)에 '자유게시판'을 추가했다. 한 곳만 고치면 게시판 12개 페이지가 함께 맞는다.

## ⚠️ base 가 develop 이 아니다

이 PR 의 base 는 **`fix/board-mobile-and-access` (#342)** 다. 자유게시판이 쓰는 `BOARD_MENUS`·`BoardList` 모바일 카드·`BoardSearchBar` 고정폭 수정이 전부 거기 있어서, develop 을 base 로 잡으면 같은 파일을 두 번 고치게 된다.

**#342 를 먼저 머지한 뒤 이 PR 의 base 를 develop 으로 바꾸면 된다.** GitHub 이 자동으로 바꿔주기도 한다.

## 권한

서버와 같은 규칙을 화면에도 건다.

| | 규칙 | 화면에서 |
|---|---|---|
| 조회 | 로그인 필수 | 목록·상세 양쪽에 게이트. 비로그인은 `/login?next=` 로 보낸다 |
| 작성 | MEMBER 이상 | 목록의 '글쓰기' 버튼, 작성 페이지 진입 |
| 수정·삭제 | 작성자 본인 또는 ORGANIZER 이상 | 상세의 버튼 노출, 수정 페이지 진입 |

**수정·삭제 버튼을 서버 규칙과 같은 조건으로 판정한다.** 행사·공지는 상세 응답에 `authorId` 가 없어서 CORE 이상 모두에게 버튼을 보여주고, 눌러야 403 을 만난다. 자유게시판은 서버가 `authorId` 를 주므로 남의 글에는 애초에 버튼이 뜨지 않는다. 수정 페이지도 URL 로 직접 들어오는 경우를 대비해 상세를 읽은 뒤 같은 판정을 한 번 더 하고, 남의 글이면 폼 대신 안내를 띄운다. (행사·공지의 같은 문제는 이 PR 범위 밖이다.)

## 구현 메모

- 목록 봉투는 행사와 같아 `unwrapPaged` 를 그대로 쓴다. 공지처럼 고정 글이 따로 오지 않는다.
- 상세는 `unwrapApiResponse` 를 쓰지 않는다 — `content`(본문) 필드가 `WRAPPER_KEYS` 의 `content` 와 부딪혀 객체 대신 본문 문자열만 돌아온다. 행사·공지와 같은 `unwrapOnce` 를 쓴다.
- `fetchFreeList`/`fetchFreeDetail` 은 `client` 를 필수로 받는다. 기본값을 `publicClient` 로 두면 토큰 없이 나가 401 이 된다.
- 첨부 S3 키는 `boardFree` — `S3KeyType` enum 의 **이름**이지 value(`board/free`)가 아니다.

## 검증

```
npx --yes yarn@1.22.22 build
```

- `Done in 27.88s`, `/board/free`·`/detail`·`/edit`·`/new` 네 라우트가 정적 생성됐다.
- lint 경고는 전부 기존 파일 것이고, 이번에 추가한 파일에서는 나오지 않았다.

브라우저 확인은 서버 #339 가 dev 에 올라간 뒤에 가능하다.

## 머지 순서

1. Server #339 → dev 배포 확인
2. Web #342
3. 이 PR (base 를 develop 으로 변경)

서버를 먼저 올려야 한다. 반대로 하면 화면이 없는 API 를 부른다.

## 남은 것

파일 첨부는 서버 PR #336(`feature/board-common`)이 머지돼야 동작한다. 링크 첨부는 지금도 된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug7rbkpZ4cgNgECyv1GEXn
