### PR TITLE
fix: 이미지 첨부를 미리보기로 보여준다

### DIFF
--- a/src/components/board/AttachmentList.tsx
+++ b/src/components/board/AttachmentList.tsx
@@ -15,6 +15,30 @@ const formatFileSize = (bytes: number): string => {
 const isFileAttachment = (attachment: AttachmentResponse): boolean =>
   attachment.kind ? attachment.kind === 'FILE' : Boolean(attachment.fileUrl ?? attachment.fileName)
 
+const IMAGE_EXTENSION = /\.(png|jpe?g|gif|webp|svg|avif)$/i
+
+/**
+ * 확장자로만 이미지를 가린다.
+ *
+ * URL 이면 경로만 본다 — presigned URL 은 ?X-Amz-... 가 붙어 확장자가 끝에 오지 않는다.
+ * URL 이 아니면(파일명) 그대로 본다.
+ *
+ * 확장자 없는 CDN 링크는 이미지여도 링크로 남는다. 일단 <img> 로 그려보고 실패하면
+ * 되돌리는 방법이 더 많이 잡지만, 일반 웹페이지 링크가 한 프레임 깨진 이미지로
+ * 보였다가 바뀐다. 놓치는 쪽을 택했다.
+ */
+const hasImageExtension = (value: string | null | undefined): boolean => {
+  if (!value) return false
+
+  let path = value
+  try {
+    path = new URL(value).pathname
+  } catch {
+    // URL 이 아니다. 파일명으로 보고 그대로 검사한다.
+  }
+  return IMAGE_EXTENSION.test(path)
+}
+
 export interface AttachmentListProps {
   attachments: AttachmentResponse[]
 }
@@ -24,34 +48,64 @@ export function AttachmentList({ attachments }: AttachmentListProps) {
 
   return (
     <ul className="flex w-full flex-col gap-2">
-      {attachments.map((attachment) => (
-        <li key={attachment.id}>
-          {isFileAttachment(attachment) ? (
+      {attachments.map((attachment) => {
+        const isFile = isFileAttachment(attachment)
+        const href = (isFile ? attachment.fileUrl : attachment.url) ?? null
+        // 파일은 원본 파일명이 확장자를 갖고 있다. 링크는 주소 자체를 본다.
+        const imageSource =
+          href && hasImageExtension(isFile ? (attachment.fileName ?? href) : href) ? href : null
+
+        if (imageSource) {
+          return (
+            <li key={attachment.id}>
+              {/* 원본을 새 탭에서 열 수 있게 감싼다. 미리보기는 max-h 로 잘라 본문을 밀지 않는다. */}
+              <a href={imageSource} target="_blank" rel="noreferrer" className="block">
+                {/* next/image 는 못 쓴다 — 임의의 외부 호스트라 remotePatterns 에 적을 수 없다. */}
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={imageSource}
+                  alt={attachment.fileName ?? '첨부 이미지'}
+                  loading="lazy"
+                  className="max-h-96 w-auto max-w-full rounded-lg"
+                />
+              </a>
+            </li>
+          )
+        }
+
+        if (isFile) {
+          return (
+            <li key={attachment.id}>
+              <a
+                href={href ?? '#'}
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-white typo-pc-b3 mobile:typo-m-b3 transition-colors hover:bg-gray-400"
+              >
+                <span className="flex-1 truncate">{attachment.fileName}</span>
+                {attachment.fileSize !== null && attachment.fileSize !== undefined && (
+                  <span className="shrink-0 text-gray-700">
+                    {formatFileSize(attachment.fileSize)}
+                  </span>
+                )}
+              </a>
+            </li>
+          )
+        }
+
+        return (
+          <li key={attachment.id}>
             <a
-              href={attachment.fileUrl ?? '#'}
-              target="_blank"
-              rel="noreferrer"
-              className="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-white typo-pc-b3 mobile:typo-m-b3 transition-colors hover:bg-gray-400"
-            >
-              <span className="flex-1 truncate">{attachment.fileName}</span>
-              {attachment.fileSize !== null && attachment.fileSize !== undefined && (
-                <span className="shrink-0 text-gray-700">
-                  {formatFileSize(attachment.fileSize)}
-                </span>
-              )}
-            </a>
-          ) : (
-            <a
-              href={attachment.url ?? '#'}
+              href={href ?? '#'}
               target="_blank"
               rel="noreferrer"
               className="flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-blue underline typo-pc-b3 mobile:typo-m-b3 transition-colors hover:bg-gray-400"
             >
               {attachment.url}
             </a>
-          )}
-        </li>
-      ))}
+          </li>
+        )
+      })}
     </ul>
   )
 }


### PR DESCRIPTION
## 무엇

이미지 첨부가 그림으로 보인다. 링크 첨부에 이미지 주소를 넣어도, 이미지 파일을 올려도 마찬가지다.

| | 전 | 후 |
|---|---|---|
| 링크 첨부 (`.../cat.png`) | `https://.../cat.png` 문자열 | 그림 (눌러서 새 탭) |
| 파일 첨부 (`cat.png`) | `cat.png  120.5KB` | 그림 (눌러서 새 탭) |
| 그 외 링크·파일 | 그대로 | 그대로 |

## 왜 확장자 판별인가

`png/jpg/jpeg/gif/webp/svg/avif` 로 끝나면 이미지로 본다. URL 이면 **경로만** 본다 — presigned URL 은 `?X-Amz-Algorithm=...` 이 붙어 확장자가 문자열 끝에 오지 않는다. 파일 첨부는 주소 대신 **원본 파일명**의 확장자를 본다.

확장자 없는 CDN 링크는 이미지여도 링크로 남는다. 일단 `<img>` 로 그려보고 `onError` 면 링크로 되돌리는 방법이 더 많이 잡지만, 일반 웹페이지 링크가 한 프레임 깨진 이미지로 보였다가 바뀐다. **놓치는 쪽을 택했다.**

`next/image` 는 쓸 수 없다. 임의의 외부 호스트라 `images.remotePatterns` 에 적을 수 없다. 저장소 관례대로 `<img>` + `eslint-disable-next-line`(`ProfileCard.tsx:41` 과 같은 방식)을 쓴다.

## 범위

`AttachmentList` 는 행사·공지·자유 세 게시판이 공유한다. **행사·공지의 기존 이미지 첨부도 함께 미리보기로 바뀐다.** 의도한 것이다.

## 검증

```
npx --yes yarn@1.22.22 build   # Done in 27.66s
```

`no-img-element` 경고 9건은 이전 빌드와 **줄·열까지 동일**하다 — 이번 `<img>` 는 경고를 추가하지 않았다(disable 이 먹었다).

판별 로직은 저장소에 테스트 인프라가 없어 **같은 로직을 node 로 옮겨 14케이스를 돌렸다**(모듈 자체를 부른 것이 아니다).

```
ok  https://example.com/a.png                      -> true
ok  https://example.com/A.PNG                      -> true
ok  https://b.s3....amazonaws.com/x.jpg?X-Amz-...  -> true
ok  https://example.com/a.png#anchor               -> true
ok  https://example.com/image                      -> false
ok  https://github.com/GDGoCINHA/24-2_GDGoC_Web    -> false
ok  https://example.com/path.png/notimage          -> false
ok  photo.jpeg / 한글이름.PNG                       -> true
ok  report.pdf / '' / null / 'not a url at all'    -> false
ALL PASS
```

브라우저에서 실제로 눌러본 것은 아니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug7rbkpZ4cgNgECyv1GEXn
