### PR TITLE
fix: 게시판 헤더 메뉴 이름과 순서를 맞춘다

### DIFF
--- a/src/components/board/boardMenus.ts
+++ b/src/components/board/boardMenus.ts
@@ -8,7 +8,7 @@ import type { GdgMenuLink } from '@/components/ui/design-system'
  * 게시판이 늘어날 때 여기 한 곳만 고치면 8개 페이지가 함께 맞는다.
  */
 export const BOARD_MENUS: GdgMenuLink[] = [
-  { label: '행사', url: '/board/events/' },
   { label: '공지사항', url: '/board/notices/' },
+  { label: '행사게시판', url: '/board/events/' },
   { label: '자유게시판', url: '/board/free/' }
 ]


### PR DESCRIPTION
## 무엇

게시판 헤더 메뉴 한 줄.

```diff
 export const BOARD_MENUS: GdgMenuLink[] = [
-  { label: '행사', url: '/board/events/' },
   { label: '공지사항', url: '/board/notices/' },
+  { label: '행사게시판', url: '/board/events/' },
   { label: '자유게시판', url: '/board/free/' }
 ]
```

'행사'만 '게시판'이 빠져 있어 셋이 나란히 놓였을 때 형식이 어긋났다. 순서는 공지사항 → 행사게시판 → 자유게시판.

게시판 12개 페이지가 이 상수 하나를 공유한다.

## 건드리지 않은 것

랜딩(`OnboardingLanding.tsx:379`)의 **'게시판'** 링크는 그대로다. 그건 게시판끼리의 이동이 아니라 랜딩 → 게시판 진입이고, 비로그인 방문자를 공개 게시판인 행사로 보내는 링크다. 이름을 '행사게시판'으로 바꾸면 "게시판 전체로 가는 입구"라는 뜻이 사라진다.

## 검증

```
npx --yes yarn@1.22.22 build   # Done in 25.28s
```

빌드 산출물 `out/board/events/index.html` 에서 순서 확인: 공지사항 → 행사게시판 → 자유게시판.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug7rbkpZ4cgNgECyv1GEXn
