### PR TITLE
fix: 랜딩의 게시판 링크 이름을 행사게시판으로 바꾼다

### DIFF
--- a/src/components/landing/OnboardingLanding.tsx
+++ b/src/components/landing/OnboardingLanding.tsx
@@ -376,7 +376,7 @@ function SiteHeader({
             href="/board/events/"
             className="typo-pc-b2 text-gray-500 transition-colors hover:text-white"
           >
-            게시판
+            행사게시판
           </a>
           {/* 로그인 상태에서도 /login?next=%2F 로 보내면 로그인 후 / 가 /onboarding 으로
               리다이렉트돼 제자리로 돌아온다. 로그인했으면 내 정보로 보낸다. */}
@@ -419,7 +419,7 @@ function MobileMenuDrawer({
     { label: '소개', action: () => onNavigate('about') },
     { label: '활동', action: () => onNavigate('activities') },
     { label: 'FAQ', action: () => onNavigate('faq') },
-    { label: '게시판', href: '/board/events/' },
+    { label: '행사게시판', href: '/board/events/' },
     { label: '마이페이지', href: '/profile' },
     ...(canSeeDashboard ? [{ label: '대시보드', href: '/dashboard' }] : [])
   ]


### PR DESCRIPTION
## 무엇

랜딩 우상단의 **'게시판'** → **'행사게시판'**. #345 에서 게시판 헤더를 '공지사항·행사게시판·자유게시판'으로 통일한 것에 맞춘다.

이 링크가 실제로 여는 것은 행사 게시판 하나다. 랜딩은 비로그인 방문자가 보는 화면이라 공개 게시판인 행사로 보낸다 — 공지·자유는 로그인이 필요해 여기서 링크하면 바로 로그인으로 튕긴다.

두 군데를 고쳤다.

- `OnboardingLanding.tsx:379` — 실제로 렌더되는 헤더 링크
- `OnboardingLanding.tsx:422` — `MobileMenuDrawer` 의 메뉴 항목

**드로어는 어디서도 렌더되지 않는 죽은 코드다.** 화면에는 영향이 없다. 되살릴 때 옛 이름이 남지 않도록 같이 맞췄을 뿐이고, 이 PR 로 모바일 동작이 바뀌지는 않는다. (모바일에서 게시판에 도달하는 수단은 `:371` 의 헤더 링크가 담당한다 — 그 주석에 이미 적혀 있다.)

## 검증

```
npx --yes yarn@1.22.22 build   # Done in 25.77s
```

랜딩 헤더는 **프리렌더 HTML 에 남지 않는다.** `out/onboarding/index.html` 에는 라벨이 없고 `out/_next/static/chunks/app/onboarding/page-*.js` 에 들어간다. 그 청크에서 확인했다.

- `행사게시판` 있음
- 독립 라벨 `"게시판"` 0건 — 옛 이름 잔존 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug7rbkpZ4cgNgECyv1GEXn
