### PR TITLE
fix: 랜딩 상단 메뉴를 소개·활동·게시판·FAQ 로 맞춘다

### DIFF
--- a/src/components/landing/OnboardingLanding.tsx
+++ b/src/components/landing/OnboardingLanding.tsx
@@ -41,14 +41,25 @@ const valueTagStateClass: Record<Accent, { active: string; inactive: string }> =
   yellow: { active: 'bg-yellow', inactive: 'bg-yellow-400' }
 }
 
+/**
+ * 게시판만 성격이 다르다. 나머지 셋은 같은 페이지의 섹션으로 스크롤하는 앵커라
+ * 활성 표시(빨간 밑줄)가 따라붙지만, 게시판은 다른 페이지로 나가므로 활성이 되지 않는다.
+ * 그래도 나란히 두는 편이 사용자에게 자연스러워 같은 줄에 놓는다.
+ *
+ * 게시판 셋 중 행사로 보낸다. 랜딩은 비로그인 방문자가 보는 화면인데 공지·자유는
+ * 로그인이 필요해서 여기서 링크하면 바로 로그인으로 튕긴다. 게시판끼리의 이동은
+ * 게시판 헤더의 BOARD_MENUS 가 담당하므로 여기서는 입구 하나만 연다.
+ */
 const navItems = [
   { label: '소개', id: 'about' },
   { label: '활동', id: 'activities' },
+  { label: '게시판', href: '/board/events/' },
   { label: 'FAQ', id: 'faq' }
 ]
 
+/** 게시판이 2번이라 FAQ 가 3번이다. 밑줄 위치가 이 값으로 계산되므로 navItems 순서와 같이 움직인다. */
 const getActiveNavIndex = (activeId: string) => {
-  if (activeId === 'faq') return 2
+  if (activeId === 'faq') return 3
   if (activeId === 'activities' || activeId === 'join') return 1
   return 0
 }
@@ -337,25 +348,38 @@ function SiteHeader({
           <GdgLogo mode="pc" variant="long" priority />
         </div>
         <nav className="relative flex h-full items-center justify-center typo-pc-b2 mobile:flex-1 mobile:typo-m-s3">
-          {navItems.map((item, index) => (
-            <a
-              key={item.label}
-              href={`#${item.id}`}
-              aria-current={index === activeNavIndex ? 'page' : undefined}
-              onClick={(event) => {
-                event.preventDefault()
-                onNavigate(item.id)
-              }}
-              className={cn(
-                'flex h-6 w-30 items-center justify-center transition-colors hover:text-white mobile:h-full mobile:flex-1 mobile:w-auto',
-                index === activeNavIndex ? 'text-white' : 'text-gray-500'
-              )}
-            >
-              {item.label}
-            </a>
-          ))}
+          {navItems.map((item, index) => {
+            const className = cn(
+              'flex h-6 w-30 items-center justify-center transition-colors hover:text-white mobile:h-full mobile:flex-1 mobile:w-auto',
+              index === activeNavIndex ? 'text-white' : 'text-gray-500'
+            )
+
+            // 게시판은 페이지 이동이라 preventDefault 를 걸지 않는다. 활성도 되지 않는다.
+            if (item.href) {
+              return (
+                <a key={item.label} href={item.href} className={className}>
+                  {item.label}
+                </a>
+              )
+            }
+
+            return (
+              <a
+                key={item.label}
+                href={`#${item.id}`}
+                aria-current={index === activeNavIndex ? 'page' : undefined}
+                onClick={(event) => {
+                  event.preventDefault()
+                  onNavigate(item.id)
+                }}
+                className={className}
+              >
+                {item.label}
+              </a>
+            )
+          })}
           <span
-            className="absolute bottom-0 left-[calc(var(--active-nav-index)*120px)] h-0.5 w-30 bg-red transition-[left] duration-300 ease-out mobile:left-[calc(var(--active-nav-index)*100%/3)] mobile:w-[calc(100%/3)]"
+            className="absolute bottom-0 left-[calc(var(--active-nav-index)*120px)] h-0.5 w-30 bg-red transition-[left] duration-300 ease-out mobile:left-[calc(var(--active-nav-index)*100%/4)] mobile:w-[calc(100%/4)]"
             style={
               {
                 '--active-nav-index': activeNavIndex
@@ -366,18 +390,8 @@ function SiteHeader({
         </nav>
         {/* mobile:hidden 을 두면 모바일에 진입 수단이 아예 없다. 같은 파일의
             MobileMenuDrawer 는 정의만 있고 렌더되지 않는 죽은 코드라, 드로어의
-            마이페이지 항목은 화면에 나오지 않는다. 게시판 링크도 같은 이유로
-            여기 둔다 — 드로어의 게시판 항목만으로는 모바일에서 도달할 수 없다. */}
+            마이페이지 항목은 화면에 나오지 않는다. */}
         <div className="flex items-center gap-4 justify-self-end">
-          {/* 랜딩은 비로그인 방문자가 보는 화면이라 공개 게시판인 행사로 보낸다.
-              공지는 로그인이 필요해서 여기서 링크하면 바로 로그인으로 튕긴다.
-              게시판끼리의 이동은 게시판 헤더의 BOARD_MENUS 가 담당한다. */}
-          <a
-            href="/board/events/"
-            className="typo-pc-b2 text-gray-500 transition-colors hover:text-white"
-          >
-            행사게시판
-          </a>
           {/* 로그인 상태에서도 /login?next=%2F 로 보내면 로그인 후 / 가 /onboarding 으로
               리다이렉트돼 제자리로 돌아온다. 로그인했으면 내 정보로 보낸다. */}
           <a
@@ -418,8 +432,8 @@ function MobileMenuDrawer({
   const menuItems = [
     { label: '소개', action: () => onNavigate('about') },
     { label: '활동', action: () => onNavigate('activities') },
+    { label: '게시판', href: '/board/events/' },
     { label: 'FAQ', action: () => onNavigate('faq') },
-    { label: '행사게시판', href: '/board/events/' },
     { label: '마이페이지', href: '/profile' },
     ...(canSeeDashboard ? [{ label: '대시보드', href: '/dashboard' }] : [])
   ]


### PR DESCRIPTION
## 무엇

랜딩 상단 메뉴가 **소개 · 활동 · 게시판 · FAQ** 순서가 된다. 이름도 '행사게시판' → **'게시판'** 으로 되돌린다(#346 되돌림).

단순 순서 변경이 아니다. 게시판 링크는 nav **밖 오른쪽**에 따로 있었다. nav 안 세 번째 자리로 옮겼다.

## 왜 이 정도 변경이 필요한가

게시판만 성격이 다르다. 나머지 셋은 같은 페이지의 섹션으로 이동하는 앵커라 활성 밑줄이 따라붙지만, **게시판은 다른 페이지로 나가므로 활성이 되지 않는다.** 그래서 `navItems` 를 섞인 배열로 두고, `href` 가 있는 항목은 `preventDefault` 없이 그냥 링크로 그린다.

밑줄은 인덱스로 위치를 계산한다(`left: calc(var(--active-nav-index) * 120px)`). 게시판이 2번이 되면서 FAQ 가 3번이 되므로 `getActiveNavIndex` 의 `faq` 반환값을 2 → 3 으로 옮겼다. 모바일은 항목이 넷이 되어 `100%/3` → `100%/4`.

`MobileMenuDrawer` 항목도 같은 순서·이름으로 맞췄다. **렌더되지 않는 죽은 코드라 화면에는 영향이 없다.**

## 검증

`npx --yes yarn@1.22.22 build` 통과. 정적 빌드를 `localhost:3000` 으로 띄워 브라우저에서 직접 확인했다.

| 항목 | left | width |
|---|---|---|
| 소개 | 0 | 120 |
| 활동 | 120 | 120 |
| 게시판 | 240 | 120 |
| FAQ | 360 | 120 |

- 게시판의 `href` 는 `/board/events/` — 앵커가 아니라 페이지 이동이다.
- FAQ 로 이동하면 `--active-nav-index` 가 `3`, `aria-current="page"` 와 `text-white` 가 FAQ 로 옮겨간다.

**모바일 폭은 확인하지 못했다.** 이 환경에서 브라우저 창을 줄여도 뷰포트에 반영되지 않는다(390 요청 → `innerWidth: 1268`, `mobileMatches: false`). `100%/4` 는 코드상 계산이고 실제 화면으로는 검증되지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug7rbkpZ4cgNgECyv1GEXn
