### PR TITLE
fix: 모바일 상단 메뉴 탭 지연을 없앤다 (검증 필요)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,10 +62,17 @@ const dunggeunmo = localFont({
   fallback: ['Pretendard', 'sans-serif']
 })
 
+/**
+ * maximumScale 을 두지 않는다. userScalable: true 와 함께 쓰면 "확대를 허용하되
+ * 확대 배율은 1배까지"라는 모순이 되고, 브라우저마다 다르게 해석한다. 확대를 실제로
+ * 막으면 접근성 문제이기도 하다.
+ *
+ * 탭 지연이 걱정되는 요소는 각자 touch-manipulation 을 쓴다 — 페이지 전체의 확대를
+ * 막는 방식으로 해결하지 않는다.
+ */
 export const viewport = {
   width: 'device-width',
   initialScale: 1.0,
-  maximumScale: 1.0,
   minimumScale: 1.0,
   userScalable: true,
   themeColor: '#000000',

--- a/src/components/landing/OnboardingLanding.tsx
+++ b/src/components/landing/OnboardingLanding.tsx
@@ -349,8 +349,11 @@ function SiteHeader({
         </div>
         <nav className="relative flex h-full items-center justify-center typo-pc-b2 mobile:flex-1 mobile:typo-m-s3">
           {navItems.map((item, index) => {
+            // touch-manipulation: 안드로이드 크롬이 더블탭 줌 여부를 기다리느라 탭마다
+            // 300ms 쯤 클릭을 늦춘다. 그 뒤에 전환 애니메이션 0.84초가 이어져 첫 탭이
+            // 먹히지 않은 것처럼 보인다. 이 요소에서 더블탭 줌을 포기해 지연을 없앤다.
             const className = cn(
-              'flex h-6 w-30 items-center justify-center transition-colors hover:text-white mobile:h-full mobile:flex-1 mobile:w-auto',
+              'flex h-6 w-30 touch-manipulation items-center justify-center transition-colors hover:text-white mobile:h-full mobile:flex-1 mobile:w-auto',
               index === activeNavIndex ? 'text-white' : 'text-gray-500'
             )
 
@@ -396,7 +399,7 @@ function SiteHeader({
               리다이렉트돼 제자리로 돌아온다. 로그인했으면 내 정보로 보낸다. */}
           <a
             href={isLoggedIn ? '/profile' : '/login?next=%2F'}
-            className="flex size-11 items-center justify-center text-gray-500 transition-colors hover:text-white"
+            className="flex size-11 touch-manipulation items-center justify-center text-gray-500 transition-colors hover:text-white"
             aria-label={isLoggedIn ? '내 정보' : '로그인'}
           >
             {loginIcon}


### PR DESCRIPTION
## ⚠️ 이건 검증되지 않은 추정이다

안드로이드 크롬에서 랜딩 상단 메뉴를 **두 번 눌러야** 반응한다는 제보(첫 탭에 아무 반응 없음, 항상 재현, PC 는 정상).

이 환경에서는 **진짜 터치 입력을 만들 수 없어 확인하지 못했다.** dev 에 올려 실제 폰으로 눌러보는 것이 유일한 검증 방법이라 머지한다. 안 고쳐지면 되돌리고 다음 후보로 간다.

## 배제한 것들

| 후보 | 결과 | 근거 |
|---|---|---|
| 요소를 가리는 오버레이 | 아님 | iframe 으로 실제 390px 모바일 레이아웃을 만들어 확인. 네 항목 모두 75×44px, 중심점 `elementFromPoint` 가 링크 자신에 닿는다 |
| 탭 타깃이 작음 | 아님 | 44px — 권장 최소치 충족 |
| hover 잔류 | 아님 | Tailwind v4 는 `hover:` 를 `@media (hover: hover)` 로 감싼다. 터치 기기엔 적용되지 않는다 |
| viewport 메타 누락 | 아님 | `width=device-width` 정상 출력 |
| 전환 잠금(0.84초) | 아님 | "항상 그렇다"와 맞지 않고, 게시판은 일반 `<a href>` 라 잠금이 막지 못한다 |

## 남은 후보와 이 PR 의 처방

**더블탭 줌 판정에 따른 클릭 지연.** 브라우저는 탭이 들어와도 두 번째 탭이 올지 300ms 쯤 기다린 뒤에야 클릭을 보낸다. 그 뒤 전환 애니메이션 0.84초(나가는 0.28 + 들어오는 0.56)가 이어져 체감상 1초 넘게 아무 일도 안 일어난다.

근거가 하나 있다. `viewport` 설정이 **모순**이었다.

```diff
 export const viewport = {
   width: 'device-width',
   initialScale: 1.0,
-  maximumScale: 1.0,   // 확대 금지
   minimumScale: 1.0,
   userScalable: true,  // 확대 허용
```

"확대를 허용하되 1배까지"는 브라우저마다 다르게 해석한다. 그리고 이 저장소에는 `touch-action` 설정이 **한 군데도 없었다.**

1. 헤더 링크에 `touch-manipulation` — 그 요소에서 더블탭 줌을 포기해 지연을 없앤다
2. `maximumScale` 제거 — 모순 해소. 확대를 실제로 막는 건 접근성 문제이기도 하다

## 범위를 헤더로 좁힌 이유

전역 규칙(`a, button { touch-action: manipulation }`)으로 덮으면 고쳐지더라도 **원인을 확인할 수 없다.** 헤더만 나아지고 다른 버튼(예: 히어로의 '지원하기')이 그대로면 진단이 맞은 것이고, 그때 전역으로 넓히면 된다.

## 검증

`npx --yes yarn@1.22.22 build` 통과. 빌드 산출물에서 확인:

```
<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, user-scalable=yes">   ← maximum-scale 사라짐
out/_next/static/css/00ea27352f34c687.css:touch-action:manipulation                                        ← 규칙 생성됨
```

**실제 터치 동작은 확인하지 못했다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug7rbkpZ4cgNgECyv1GEXn
