### PR TITLE
feat: 휴지통 화면·자유게시판 댓글·수정삭제 버튼 판정

### DIFF
--- a/src/app/board/events/detail/page.tsx
+++ b/src/app/board/events/detail/page.tsx
@@ -85,7 +85,20 @@ export default function EventBoardDetailPage() {
     }
   }, [apiClient, id, router])
 
-  const canManage = hasAtLeast(user?.userRole, 'CORE')
+  /**
+   * 서버 규칙(EventBoardService.requireTeamAccess)과 같은 조건이다.
+   * ORGANIZER 이상이거나, 그 아래는 주최 팀이 자기 팀과 같아야 한다.
+   *
+   * 전에는 CORE 이상 전원에게 버튼을 띄우고 거부는 403 에 맡겼다. 팀이 다르면
+   * 눌러야 막히는 걸 알 수 있었다. organizingTeam 은 상세 응답에 원래 있던 값이다.
+   *
+   * 팀이 없는 회원(user.team == null)에게 버튼이 뜨지 않는 것도 서버와 같다 —
+   * requireTeamAccess 가 userTeam == null 을 403 으로 본다.
+   */
+  const canManage =
+    detail !== null &&
+    (hasAtLeast(user?.userRole, 'ORGANIZER') ||
+      (user?.team != null && user.team === detail.organizingTeam))
 
   if (loading) {
     return <p className="py-16 text-center text-white typo-pc-b2 mobile:typo-m-b2">불러오는 중...</p>

--- a/src/app/board/events/edit/page.tsx
+++ b/src/app/board/events/edit/page.tsx
@@ -58,6 +58,8 @@ export default function EventBoardEditPage() {
 
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
+  // 다른 팀 행사면 서버가 403 을 줄 것을 미리 알아내 폼 대신 안내를 띄운다.
+  const [forbidden, setForbidden] = useState(false)
 
   const [title, setTitle] = useState('')
   const [eventStartDate, setEventStartDate] = useState('')
@@ -88,6 +90,17 @@ export default function EventBoardEditPage() {
     fetchEventDetail(id)
       .then((detail) => {
         if (!alive) return
+
+        // 서버 규칙(EventBoardService.requireTeamAccess)과 같은 조건이다.
+        // CORE 라고 다른 팀 행사를 고칠 수 있는 것이 아니다.
+        const allowed =
+          hasAtLeast(user?.userRole, 'ORGANIZER') ||
+          (user?.team != null && user.team === detail.organizingTeam)
+        if (!allowed) {
+          setForbidden(true)
+          return
+        }
+
         setTitle(detail.title)
         setEventStartDate(detail.eventStartDate)
         setEventEndDate(detail.eventEndDate)
@@ -116,7 +129,7 @@ export default function EventBoardEditPage() {
     return () => {
       alive = false
     }
-  }, [id])
+  }, [id, user?.team, user?.userRole])
 
   const handleThumbnailSelect = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
@@ -194,6 +207,14 @@ export default function EventBoardEditPage() {
     return (
       <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
         <p className="typo-pc-b2 mobile:typo-m-b2">수정 권한이 없습니다.</p>
+      </main>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
+        <p className="typo-pc-b2 mobile:typo-m-b2">주최 팀만 수정할 수 있습니다.</p>
       </main>
     )
   }

--- a/src/app/board/events/page.tsx
+++ b/src/app/board/events/page.tsx
@@ -94,15 +94,25 @@ export default function EventBoardListPage() {
       />
       <div className="mx-auto w-full max-w-[1120px] space-y-6 px-6 mobile:px-4 py-10">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h1 className="typo-pc-h3 mobile:typo-m-h2">행사 게시판</h1>
-          {canWrite && (
-            <Link
-              href="/board/events/new/"
-              className="rounded-full bg-red px-6 py-2 typo-pc-b3 mobile:typo-m-b3 text-white"
-            >
-              글쓰기
-            </Link>
-          )}
+          <h1 className="typo-pc-h3 mobile:typo-m-h2">행사게시판</h1>
+          <div className="flex flex-wrap items-center gap-3">
+            {canWrite && (
+              <Link
+                href="/board/events/trash/"
+                className="rounded-full border border-gray-800 px-6 py-2 typo-pc-b3 mobile:typo-m-b3"
+              >
+                휴지통
+              </Link>
+            )}
+            {canWrite && (
+              <Link
+                href="/board/events/new/"
+                className="rounded-full bg-red px-6 py-2 typo-pc-b3 mobile:typo-m-b3 text-white"
+              >
+                글쓰기
+              </Link>
+            )}
+          </div>
         </div>
 
         <BoardSearchBar

--- a/src/app/board/events/trash/page.tsx
+++ b/src/app/board/events/trash/page.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useState } from 'react'
+
+import { BoardList, type BoardListColumn } from '@/components/board/BoardList'
+import { BoardPagination } from '@/components/board/BoardPagination'
+import { BOARD_MENUS } from '@/components/board/boardMenus'
+import { GdgSiteHeader } from '@/components/ui/design-system'
+import { useAuth } from '@/hooks/useAuth'
+import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
+import { fetchDeletedEvents, restoreEvent } from '@/services/board/boardClient'
+import type { DeletedEventBoardSummary } from '@/types/board'
+import type { PageMeta } from '@/utils/api/unwrapPaged'
+import { hasAtLeast } from '@/utils/auth/role'
+import { formatDate } from '@/utils/formatDate'
+
+export default function EventBoardTrashPage() {
+  const { user } = useAuth()
+  const { apiClient } = useAuthenticatedApi()
+
+  const [page, setPage] = useState(0)
+  const [items, setItems] = useState<DeletedEventBoardSummary[]>([])
+  const [meta, setMeta] = useState<PageMeta | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [restoringId, setRestoringId] = useState<number | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
+
+  // 서버와 같은 경계다. ORGANIZER 미만에게는 서버가 자기 팀 행사만 준다.
+  const canOpen = hasAtLeast(user?.userRole, 'CORE')
+
+  useEffect(() => {
+    if (!canOpen) return
+
+    let alive = true
+    setLoading(true)
+    setError(null)
+
+    fetchDeletedEvents({ page, size: 12 }, apiClient)
+      .then((result) => {
+        if (!alive) return
+        setItems(result.items)
+        setMeta(result.meta)
+      })
+      .catch(() => {
+        if (alive) setError('휴지통을 불러오지 못했습니다.')
+      })
+      .finally(() => {
+        if (alive) setLoading(false)
+      })
+
+    return () => {
+      alive = false
+    }
+  }, [apiClient, canOpen, page, reloadKey])
+
+  const handleRestore = useCallback(
+    async (id: number) => {
+      setRestoringId(id)
+      try {
+        await restoreEvent(apiClient, id)
+        setReloadKey((key) => key + 1)
+      } catch {
+        alert('복원에 실패했습니다.')
+      } finally {
+        setRestoringId(null)
+      }
+    },
+    [apiClient]
+  )
+
+  const columns: BoardListColumn<DeletedEventBoardSummary>[] = [
+    { key: 'title', header: '제목', primary: true, render: (item) => item.title },
+    {
+      key: 'team',
+      header: '주최',
+      render: (item) => item.organizingTeam ?? '-',
+      className: 'w-28'
+    },
+    {
+      key: 'period',
+      header: '기간',
+      render: (item) => `${formatDate(item.eventStartDate)} ~ ${formatDate(item.eventEndDate)}`,
+      className: 'w-56'
+    },
+    {
+      key: 'deletedAt',
+      header: '삭제일',
+      render: (item) => formatDate(item.deletedAt),
+      className: 'w-32'
+    },
+    {
+      key: 'restore',
+      header: '',
+      className: 'w-24',
+      render: (item) => (
+        <button
+          type="button"
+          onClick={() => handleRestore(item.id)}
+          disabled={restoringId === item.id}
+          className="rounded-full border border-gray-800 px-4 py-1 typo-pc-c1 mobile:typo-m-c1 disabled:opacity-50"
+        >
+          {restoringId === item.id ? '복원 중' : '복원'}
+        </button>
+      )
+    }
+  ]
+
+  if (!canOpen) {
+    return (
+      <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
+        <p className="typo-pc-b2 mobile:typo-m-b2">접근 권한이 없습니다.</p>
+      </main>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-black text-white">
+      <GdgSiteHeader menus={BOARD_MENUS} actionMenu={{ label: '내 정보', url: '/profile/' }} />
+      <div className="mx-auto w-full max-w-[1120px] space-y-6 px-6 mobile:px-4 py-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h1 className="typo-pc-h3 mobile:typo-m-h2">행사게시판 휴지통</h1>
+          <Link href="/board/events/" className="underline typo-pc-b3 mobile:typo-m-b3">
+            목록으로
+          </Link>
+        </div>
+
+        {/* 공지·자유가 '본인 글만'인 것과 달리 행사는 팀 기준이다 (requireTeamAccess). */}
+        {!hasAtLeast(user?.userRole, 'ORGANIZER') && (
+          <p className="text-gray-600 typo-pc-c1 mobile:typo-m-c1">
+            소속 팀이 주최한 행사만 보입니다.
+          </p>
+        )}
+
+        {error && <p className="text-red typo-pc-b3 mobile:typo-m-b3">{error}</p>}
+
+        {loading && (
+          <p className="py-16 text-center text-gray-500 typo-pc-b2 mobile:typo-m-b2">
+            불러오는 중...
+          </p>
+        )}
+        {!loading && !error && (
+          <BoardList
+            items={items}
+            columns={columns}
+            getRowKey={(item) => item.id}
+            emptyMessage="휴지통이 비어 있습니다."
+          />
+        )}
+
+        {meta && (
+          <BoardPagination page={meta.page} totalPages={meta.totalPages} onPageChange={setPage} />
+        )}
+      </div>
+    </main>
+  )
+}

--- a/src/app/board/free/detail/page.tsx
+++ b/src/app/board/free/detail/page.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { AttachmentList } from '@/components/board/AttachmentList'
 import { BOARD_MENUS } from '@/components/board/boardMenus'
+import { FreeBoardComments } from '@/components/board/FreeBoardComments'
 import { GdgSiteHeader } from '@/components/ui/design-system'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
@@ -162,6 +163,8 @@ export default function FreeBoardDetailPage() {
         <p className="whitespace-pre-wrap typo-pc-b2 mobile:typo-m-b2">{detail.content}</p>
 
         <AttachmentList attachments={detail.attachments} />
+
+        <FreeBoardComments postId={detail.id} apiClient={apiClient} />
 
         {canManage && (
           <div className="flex gap-3 border-t border-gray-800 pt-6">

--- a/src/app/board/free/page.tsx
+++ b/src/app/board/free/page.tsx
@@ -107,14 +107,25 @@ export default function FreeBoardListPage() {
       <div className="mx-auto w-full max-w-[1120px] space-y-6 px-6 mobile:px-4 py-10">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <h1 className="typo-pc-h3 mobile:typo-m-h2">자유게시판</h1>
-          {canWrite && (
-            <Link
-              href="/board/free/new/"
-              className="rounded-full bg-red px-6 py-2 text-white typo-pc-b3 mobile:typo-m-b3"
-            >
-              글쓰기
-            </Link>
-          )}
+          <div className="flex flex-wrap items-center gap-3">
+            {/* 휴지통은 MEMBER 이상이면 열린다 — 자기가 지운 글만 보인다. */}
+            {canWrite && (
+              <Link
+                href="/board/free/trash/"
+                className="rounded-full border border-gray-800 px-6 py-2 typo-pc-b3 mobile:typo-m-b3"
+              >
+                휴지통
+              </Link>
+            )}
+            {canWrite && (
+              <Link
+                href="/board/free/new/"
+                className="rounded-full bg-red px-6 py-2 text-white typo-pc-b3 mobile:typo-m-b3"
+              >
+                글쓰기
+              </Link>
+            )}
+          </div>
         </div>
 
         <BoardSearchBar

--- a/src/app/board/free/trash/page.tsx
+++ b/src/app/board/free/trash/page.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useState } from 'react'
+
+import { BoardList, type BoardListColumn } from '@/components/board/BoardList'
+import { BoardPagination } from '@/components/board/BoardPagination'
+import { BOARD_MENUS } from '@/components/board/boardMenus'
+import { GdgSiteHeader } from '@/components/ui/design-system'
+import { useAuth } from '@/hooks/useAuth'
+import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
+import { fetchDeletedFreePosts, restoreFreePost } from '@/services/board/freeClient'
+import type { DeletedFreeBoardSummary } from '@/types/free'
+import type { PageMeta } from '@/utils/api/unwrapPaged'
+import { hasAtLeast } from '@/utils/auth/role'
+import { formatDate } from '@/utils/formatDate'
+
+export default function FreeBoardTrashPage() {
+  const { user } = useAuth()
+  const { apiClient } = useAuthenticatedApi()
+
+  const [page, setPage] = useState(0)
+  const [items, setItems] = useState<DeletedFreeBoardSummary[]>([])
+  const [meta, setMeta] = useState<PageMeta | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [restoringId, setRestoringId] = useState<number | null>(null)
+  // 복원하면 그 행이 목록에서 빠져야 하므로 다시 읽는다.
+  const [reloadKey, setReloadKey] = useState(0)
+
+  // 서버와 같은 경계다. MEMBER 이상이면 열리고, ORGANIZER 미만에게는 서버가 자기 글만 준다.
+  const canOpen = hasAtLeast(user?.userRole, 'MEMBER')
+
+  useEffect(() => {
+    if (!canOpen) return
+
+    let alive = true
+    setLoading(true)
+    setError(null)
+
+    fetchDeletedFreePosts({ page, size: 15 }, apiClient)
+      .then((result) => {
+        if (!alive) return
+        setItems(result.items)
+        setMeta(result.meta)
+      })
+      .catch(() => {
+        if (alive) setError('휴지통을 불러오지 못했습니다.')
+      })
+      .finally(() => {
+        if (alive) setLoading(false)
+      })
+
+    return () => {
+      alive = false
+    }
+  }, [apiClient, canOpen, page, reloadKey])
+
+  const handleRestore = useCallback(
+    async (id: number) => {
+      setRestoringId(id)
+      try {
+        await restoreFreePost(apiClient, id)
+        setReloadKey((key) => key + 1)
+      } catch {
+        alert('복원에 실패했습니다.')
+      } finally {
+        setRestoringId(null)
+      }
+    },
+    [apiClient]
+  )
+
+  const columns: BoardListColumn<DeletedFreeBoardSummary>[] = [
+    { key: 'title', header: '제목', primary: true, render: (item) => item.title },
+    { key: 'author', header: '작성자', render: (item) => item.authorName, className: 'w-32' },
+    {
+      key: 'deletedAt',
+      header: '삭제일',
+      render: (item) => formatDate(item.deletedAt),
+      className: 'w-32'
+    },
+    {
+      key: 'restore',
+      header: '',
+      className: 'w-24',
+      render: (item) => (
+        <button
+          type="button"
+          onClick={() => handleRestore(item.id)}
+          disabled={restoringId === item.id}
+          className="rounded-full border border-gray-800 px-4 py-1 typo-pc-c1 mobile:typo-m-c1 disabled:opacity-50"
+        >
+          {restoringId === item.id ? '복원 중' : '복원'}
+        </button>
+      )
+    }
+  ]
+
+  if (!canOpen) {
+    return (
+      <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
+        <p className="typo-pc-b2 mobile:typo-m-b2">로그인이 필요합니다.</p>
+      </main>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-black text-white">
+      <GdgSiteHeader menus={BOARD_MENUS} actionMenu={{ label: '내 정보', url: '/profile/' }} />
+      <div className="mx-auto w-full max-w-[1120px] space-y-6 px-6 mobile:px-4 py-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h1 className="typo-pc-h3 mobile:typo-m-h2">자유게시판 휴지통</h1>
+          <Link href="/board/free/" className="underline typo-pc-b3 mobile:typo-m-b3">
+            목록으로
+          </Link>
+        </div>
+
+        {/* 운영진이 아니면 자기 글만 보인다. 안 보인다고 없는 것이 아니라는 걸 알려준다. */}
+        {!hasAtLeast(user?.userRole, 'ORGANIZER') && (
+          <p className="text-gray-600 typo-pc-c1 mobile:typo-m-c1">
+            본인이 삭제한 글만 보입니다.
+          </p>
+        )}
+
+        {error && <p className="text-red typo-pc-b3 mobile:typo-m-b3">{error}</p>}
+
+        {loading && (
+          <p className="py-16 text-center text-gray-500 typo-pc-b2 mobile:typo-m-b2">
+            불러오는 중...
+          </p>
+        )}
+        {!loading && !error && (
+          <BoardList
+            items={items}
+            columns={columns}
+            getRowKey={(item) => item.id}
+            emptyMessage="휴지통이 비어 있습니다."
+          />
+        )}
+
+        {meta && (
+          <BoardPagination page={meta.page} totalPages={meta.totalPages} onPageChange={setPage} />
+        )}
+      </div>
+    </main>
+  )
+}

--- a/src/app/board/notices/detail/page.tsx
+++ b/src/app/board/notices/detail/page.tsx
@@ -31,7 +31,15 @@ export default function NoticeBoardDetailPage() {
   const [error, setError] = useState<string | null>(null)
   const [deleting, setDeleting] = useState(false)
 
-  const canManage = hasAtLeast(user?.userRole, 'CORE')
+  /**
+   * 서버 규칙(NoticeBoardService.requireAuthorOrOrganizer)과 같은 조건이다.
+   * 전에는 CORE 이상 전원에게 버튼을 띄우고 거부는 403 에 맡겼다 — 상세 응답에
+   * authorId 가 없어 본인 여부를 판정할 수 없었기 때문이다. 이제 서버가 준다.
+   */
+  const canManage =
+    detail !== null &&
+    (hasAtLeast(user?.userRole, 'ORGANIZER') ||
+      (user?.id !== undefined && user.id === detail.authorId))
   // 공지는 회원 전용이다. 목록과 같은 게이트를 상세에도 건다 — 링크로 직접 들어올 수 있다.
   const isLoggedIn = Boolean(user)
 

--- a/src/app/board/notices/edit/page.tsx
+++ b/src/app/board/notices/edit/page.tsx
@@ -52,6 +52,8 @@ export default function NoticeBoardEditPage() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   const canManage = hasAtLeast(user?.userRole, 'CORE')
+  // 남의 글이면 서버가 403 을 줄 것을 미리 알아내 폼 대신 안내를 띄운다.
+  const [forbidden, setForbidden] = useState(false)
 
   useEffect(() => {
     if (!canManage) return
@@ -66,6 +68,17 @@ export default function NoticeBoardEditPage() {
     fetchNoticeDetail(id, apiClient)
       .then((detail) => {
         if (!alive) return
+
+        // 서버 규칙(NoticeBoardService.requireAuthorOrOrganizer)과 같은 조건이다.
+        // CORE 라고 남의 공지를 고칠 수 있는 것이 아니다.
+        const allowed =
+          hasAtLeast(user?.userRole, 'ORGANIZER') ||
+          (user?.id !== undefined && user.id === detail.authorId)
+        if (!allowed) {
+          setForbidden(true)
+          return
+        }
+
         setTitle(detail.title)
         setCategory(detail.category)
         setContent(detail.content)
@@ -91,7 +104,7 @@ export default function NoticeBoardEditPage() {
     return () => {
       alive = false
     }
-  }, [apiClient, canManage, id])
+  }, [apiClient, canManage, id, user?.id, user?.userRole])
 
   const handleSubmit = useCallback(async () => {
     if (!Number.isFinite(id)) return
@@ -141,6 +154,14 @@ export default function NoticeBoardEditPage() {
 
   if (loading) {
     return <p className="py-16 text-center text-white typo-pc-b2 mobile:typo-m-b2">불러오는 중...</p>
+  }
+
+  if (forbidden) {
+    return (
+      <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
+        <p className="typo-pc-b2 mobile:typo-m-b2">본인이 쓴 공지만 수정할 수 있습니다.</p>
+      </main>
+    )
   }
 
   if (loadError) {

--- a/src/app/board/notices/page.tsx
+++ b/src/app/board/notices/page.tsx
@@ -138,7 +138,15 @@ export default function NoticeBoardListPage() {
       <div className="mx-auto w-full max-w-[1120px] space-y-6 px-6 mobile:px-4 py-10">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <h1 className="typo-pc-h3 mobile:typo-m-h2">공지사항</h1>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-3">
+            {canWrite && (
+              <Link
+                href="/board/notices/trash/"
+                className="rounded-full border border-gray-800 px-6 py-2 typo-pc-b3 mobile:typo-m-b3"
+              >
+                휴지통
+              </Link>
+            )}
             {canPin && (
               <button
                 type="button"

--- a/src/app/board/notices/trash/page.tsx
+++ b/src/app/board/notices/trash/page.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useState } from 'react'
+
+import { BoardList, type BoardListColumn } from '@/components/board/BoardList'
+import { BoardPagination } from '@/components/board/BoardPagination'
+import { BOARD_MENUS } from '@/components/board/boardMenus'
+import { NoticeCategoryTag } from '@/components/board/NoticeCategoryTag'
+import { GdgSiteHeader } from '@/components/ui/design-system'
+import { useAuth } from '@/hooks/useAuth'
+import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
+import { fetchDeletedNotices, restoreNotice } from '@/services/board/noticeClient'
+import type { DeletedNoticeSummary } from '@/types/notice'
+import type { PageMeta } from '@/utils/api/unwrapPaged'
+import { hasAtLeast } from '@/utils/auth/role'
+import { formatDate } from '@/utils/formatDate'
+
+export default function NoticeBoardTrashPage() {
+  const { user } = useAuth()
+  const { apiClient } = useAuthenticatedApi()
+
+  const [page, setPage] = useState(0)
+  const [items, setItems] = useState<DeletedNoticeSummary[]>([])
+  const [meta, setMeta] = useState<PageMeta | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [restoringId, setRestoringId] = useState<number | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
+
+  // 서버와 같은 경계다. ORGANIZER 미만에게는 서버가 자기 글만 준다.
+  const canOpen = hasAtLeast(user?.userRole, 'CORE')
+
+  useEffect(() => {
+    if (!canOpen) return
+
+    let alive = true
+    setLoading(true)
+    setError(null)
+
+    fetchDeletedNotices({ page, size: 15 }, apiClient)
+      .then((result) => {
+        if (!alive) return
+        setItems(result.items)
+        setMeta(result.meta)
+      })
+      .catch(() => {
+        if (alive) setError('휴지통을 불러오지 못했습니다.')
+      })
+      .finally(() => {
+        if (alive) setLoading(false)
+      })
+
+    return () => {
+      alive = false
+    }
+  }, [apiClient, canOpen, page, reloadKey])
+
+  const handleRestore = useCallback(
+    async (id: number) => {
+      setRestoringId(id)
+      try {
+        await restoreNotice(apiClient, id)
+        setReloadKey((key) => key + 1)
+      } catch {
+        alert('복원에 실패했습니다.')
+      } finally {
+        setRestoringId(null)
+      }
+    },
+    [apiClient]
+  )
+
+  const columns: BoardListColumn<DeletedNoticeSummary>[] = [
+    {
+      key: 'category',
+      header: '분류',
+      render: (item) => <NoticeCategoryTag category={item.category} />,
+      className: 'w-24'
+    },
+    { key: 'title', header: '제목', primary: true, render: (item) => item.title },
+    { key: 'author', header: '작성자', render: (item) => item.authorName, className: 'w-32' },
+    {
+      key: 'deletedAt',
+      header: '삭제일',
+      render: (item) => formatDate(item.deletedAt),
+      className: 'w-32'
+    },
+    {
+      key: 'restore',
+      header: '',
+      className: 'w-24',
+      render: (item) => (
+        <button
+          type="button"
+          onClick={() => handleRestore(item.id)}
+          disabled={restoringId === item.id}
+          className="rounded-full border border-gray-800 px-4 py-1 typo-pc-c1 mobile:typo-m-c1 disabled:opacity-50"
+        >
+          {restoringId === item.id ? '복원 중' : '복원'}
+        </button>
+      )
+    }
+  ]
+
+  if (!canOpen) {
+    return (
+      <main className="min-h-screen bg-black px-6 py-16 text-center text-white">
+        <p className="typo-pc-b2 mobile:typo-m-b2">접근 권한이 없습니다.</p>
+      </main>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-black text-white">
+      <GdgSiteHeader menus={BOARD_MENUS} actionMenu={{ label: '내 정보', url: '/profile/' }} />
+      <div className="mx-auto w-full max-w-[1120px] space-y-6 px-6 mobile:px-4 py-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h1 className="typo-pc-h3 mobile:typo-m-h2">공지사항 휴지통</h1>
+          <Link href="/board/notices/" className="underline typo-pc-b3 mobile:typo-m-b3">
+            목록으로
+          </Link>
+        </div>
+
+        {!hasAtLeast(user?.userRole, 'ORGANIZER') && (
+          <p className="text-gray-600 typo-pc-c1 mobile:typo-m-c1">
+            본인이 삭제한 공지만 보입니다.
+          </p>
+        )}
+
+        {error && <p className="text-red typo-pc-b3 mobile:typo-m-b3">{error}</p>}
+
+        {loading && (
+          <p className="py-16 text-center text-gray-500 typo-pc-b2 mobile:typo-m-b2">
+            불러오는 중...
+          </p>
+        )}
+        {!loading && !error && (
+          <BoardList
+            items={items}
+            columns={columns}
+            getRowKey={(item) => item.id}
+            emptyMessage="휴지통이 비어 있습니다."
+          />
+        )}
+
+        {meta && (
+          <BoardPagination page={meta.page} totalPages={meta.totalPages} onPageChange={setPage} />
+        )}
+      </div>
+    </main>
+  )
+}

--- a/src/components/board/FreeBoardComments.tsx
+++ b/src/components/board/FreeBoardComments.tsx
@@ -1,0 +1,276 @@
+'use client'
+
+import type { AxiosInstance } from 'axios'
+import { useCallback, useEffect, useState } from 'react'
+
+import { GdgButton, GdgTextarea } from '@/components/ui/design-system'
+import { useAuth } from '@/hooks/useAuth'
+import {
+  createFreeComment,
+  deleteFreeComment,
+  fetchFreeComments,
+  updateFreeComment
+} from '@/services/board/freeClient'
+import type { FreeBoardComment } from '@/types/free'
+import { hasAtLeast } from '@/utils/auth/role'
+import { formatDate } from '@/utils/formatDate'
+
+export interface FreeBoardCommentsProps {
+  postId: number
+  apiClient: AxiosInstance
+}
+
+/**
+ * 자유게시판 댓글.
+ *
+ * 대댓글은 1단계까지다. 대댓글에도 '답글'을 띄우지만 서버가 같은 최상위 댓글에 붙이므로
+ * 깊이는 더 늘지 않는다. 화면에서 들여쓰기가 두 단계를 넘지 않는 이유다.
+ */
+export function FreeBoardComments({ postId, apiClient }: FreeBoardCommentsProps) {
+  const { user } = useAuth()
+
+  const [comments, setComments] = useState<FreeBoardComment[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [input, setInput] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  // 답글을 달 대상. null 이면 최상위 댓글을 쓰는 중이다.
+  const [replyTo, setReplyTo] = useState<number | null>(null)
+  const [replyInput, setReplyInput] = useState('')
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [editInput, setEditInput] = useState('')
+  const [reloadKey, setReloadKey] = useState(0)
+
+  const canWrite = hasAtLeast(user?.userRole, 'MEMBER')
+
+  useEffect(() => {
+    let alive = true
+    setLoading(true)
+    setError(null)
+
+    fetchFreeComments(postId, apiClient)
+      .then((result) => {
+        if (alive) setComments(result)
+      })
+      .catch(() => {
+        if (alive) setError('댓글을 불러오지 못했습니다.')
+      })
+      .finally(() => {
+        if (alive) setLoading(false)
+      })
+
+    return () => {
+      alive = false
+    }
+  }, [apiClient, postId, reloadKey])
+
+  const reload = useCallback(() => setReloadKey((key) => key + 1), [])
+
+  const submit = useCallback(
+    async (content: string, parentId?: number) => {
+      if (!content.trim()) return
+      setSubmitting(true)
+      try {
+        await createFreeComment(apiClient, postId, { content: content.trim(), parentId })
+        setInput('')
+        setReplyInput('')
+        setReplyTo(null)
+        reload()
+      } catch {
+        alert('댓글 작성에 실패했습니다.')
+      } finally {
+        setSubmitting(false)
+      }
+    },
+    [apiClient, postId, reload]
+  )
+
+  const submitEdit = useCallback(
+    async (commentId: number) => {
+      if (!editInput.trim()) return
+      setSubmitting(true)
+      try {
+        await updateFreeComment(apiClient, commentId, editInput.trim())
+        setEditingId(null)
+        setEditInput('')
+        reload()
+      } catch {
+        alert('댓글 수정에 실패했습니다.')
+      } finally {
+        setSubmitting(false)
+      }
+    },
+    [apiClient, editInput, reload]
+  )
+
+  const remove = useCallback(
+    async (commentId: number) => {
+      if (!window.confirm('댓글을 삭제하시겠습니까?')) return
+      try {
+        await deleteFreeComment(apiClient, commentId)
+        reload()
+      } catch {
+        alert('댓글 삭제에 실패했습니다.')
+      }
+    },
+    [apiClient, reload]
+  )
+
+  /** 서버 규칙(FreeBoardCommentService.requireAuthorOrOrganizer)과 같은 조건이다. */
+  const canManage = (comment: FreeBoardComment): boolean => {
+    if (comment.deleted) return false
+    if (hasAtLeast(user?.userRole, 'ORGANIZER')) return true
+    return user?.id !== undefined && user.id === comment.authorId
+  }
+
+  const renderComment = (comment: FreeBoardComment, isReply: boolean) => (
+    <li key={comment.id} className={isReply ? 'border-l border-gray-200 pl-4' : ''}>
+      <div className="flex flex-col gap-1 py-3">
+        {comment.deleted ? (
+          <p className="text-gray-600 typo-pc-b3 mobile:typo-m-b3">삭제된 댓글입니다.</p>
+        ) : (
+          <>
+            <div className="flex flex-wrap items-center gap-3 text-gray-500 typo-pc-c1 mobile:typo-m-c1">
+              <span className="text-white">{comment.authorName}</span>
+              <span>{formatDate(comment.createdAt)}</span>
+            </div>
+
+            {editingId === comment.id ? (
+              <div className="flex flex-col gap-2 pt-1">
+                <GdgTextarea
+                  fullWidth
+                  rows={3}
+                  value={editInput}
+                  onChange={(event) => setEditInput(event.target.value)}
+                />
+                <div className="flex gap-2">
+                  <GdgButton
+                    variant="active"
+                    onClick={() => submitEdit(comment.id)}
+                    loading={submitting}
+                  >
+                    저장
+                  </GdgButton>
+                  <button
+                    type="button"
+                    onClick={() => setEditingId(null)}
+                    className="rounded-full border border-gray-800 px-4 py-1 typo-pc-c1 mobile:typo-m-c1"
+                  >
+                    취소
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <p className="whitespace-pre-wrap typo-pc-b3 mobile:typo-m-b3">{comment.content}</p>
+            )}
+          </>
+        )}
+
+        {editingId !== comment.id && (
+          <div className="flex flex-wrap gap-3 pt-1 text-gray-600 typo-pc-c1 mobile:typo-m-c1">
+            {canWrite && !comment.deleted && (
+              <button
+                type="button"
+                onClick={() => {
+                  setReplyTo(replyTo === comment.id ? null : comment.id)
+                  setReplyInput('')
+                }}
+                className="hover:text-white"
+              >
+                답글
+              </button>
+            )}
+            {canManage(comment) && (
+              <>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingId(comment.id)
+                    setEditInput(comment.content ?? '')
+                  }}
+                  className="hover:text-white"
+                >
+                  수정
+                </button>
+                <button
+                  type="button"
+                  onClick={() => remove(comment.id)}
+                  className="hover:text-red"
+                >
+                  삭제
+                </button>
+              </>
+            )}
+          </div>
+        )}
+
+        {replyTo === comment.id && (
+          <div className="flex flex-col gap-2 pt-2">
+            <GdgTextarea
+              fullWidth
+              rows={2}
+              value={replyInput}
+              onChange={(event) => setReplyInput(event.target.value)}
+            />
+            <div className="flex gap-2">
+              <GdgButton
+                variant="active"
+                onClick={() => submit(replyInput, comment.id)}
+                loading={submitting}
+              >
+                답글 등록
+              </GdgButton>
+              <button
+                type="button"
+                onClick={() => setReplyTo(null)}
+                className="rounded-full border border-gray-800 px-4 py-1 typo-pc-c1 mobile:typo-m-c1"
+              >
+                취소
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {comment.replies.length > 0 && (
+        <ul className="ml-4 flex flex-col">
+          {comment.replies.map((reply) => renderComment(reply, true))}
+        </ul>
+      )}
+    </li>
+  )
+
+  return (
+    <section className="flex flex-col gap-4 border-t border-gray-800 pt-6">
+      <h2 className="typo-pc-s2 mobile:typo-m-s3">댓글</h2>
+
+      {error && <p className="text-red typo-pc-b3 mobile:typo-m-b3">{error}</p>}
+      {loading && <p className="text-gray-500 typo-pc-b3 mobile:typo-m-b3">불러오는 중...</p>}
+
+      {!loading && !error && comments.length === 0 && (
+        <p className="text-gray-500 typo-pc-b3 mobile:typo-m-b3">첫 댓글을 남겨보세요.</p>
+      )}
+
+      {!loading && !error && comments.length > 0 && (
+        <ul className="flex flex-col divide-y divide-gray-100">
+          {comments.map((comment) => renderComment(comment, false))}
+        </ul>
+      )}
+
+      {canWrite && (
+        <div className="flex flex-col gap-2 pt-2">
+          <GdgTextarea
+            fullWidth
+            rows={3}
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+          />
+          <GdgButton variant="active" onClick={() => submit(input)} loading={submitting}>
+            댓글 등록
+          </GdgButton>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/services/board/boardClient.ts
+++ b/src/services/board/boardClient.ts
@@ -3,6 +3,7 @@ import type { AxiosInstance } from 'axios'
 import { publicClient } from '@/lib/api/publicClient'
 import { unwrapPaged, type PagedResult } from '@/utils/api/unwrapPaged'
 import type {
+  DeletedEventBoardSummary,
   EventBoardCreatePayload,
   EventBoardDetail,
   EventBoardSummary,
@@ -61,4 +62,22 @@ export const updateEvent = async (
 
 export const deleteEvent = async (apiClient: AxiosInstance, id: number): Promise<void> => {
   await apiClient.delete(`/board/events/${id}`)
+}
+
+/**
+ * 휴지통. 목록·상세와 달리 publicClient 를 쓰지 않는다 — CORE 이상 전용이라
+ * 토큰이 없으면 401 이다. 서버는 ORGANIZER 미만에게 자기 팀 것만 걸러서 준다.
+ */
+export const fetchDeletedEvents = async (
+  params: { page?: number; size?: number },
+  apiClient: AxiosInstance
+): Promise<PagedResult<DeletedEventBoardSummary>> => {
+  const response = await apiClient.get('/board/events/deleted', {
+    params: { page: params.page ?? 0, size: params.size ?? 12 }
+  })
+  return unwrapPaged<DeletedEventBoardSummary>(response.data)
+}
+
+export const restoreEvent = async (apiClient: AxiosInstance, id: number): Promise<void> => {
+  await apiClient.post(`/board/events/${id}/restore`)
 }

--- a/src/services/board/freeClient.ts
+++ b/src/services/board/freeClient.ts
@@ -1,6 +1,8 @@
 import type { AxiosInstance } from 'axios'
 
 import type {
+  DeletedFreeBoardSummary,
+  FreeBoardComment,
   FreeBoardCreatePayload,
   FreeBoardDetail,
   FreeBoardSummary,
@@ -71,4 +73,62 @@ export const updateFreePost = async (
 
 export const deleteFreePost = async (apiClient: AxiosInstance, id: number): Promise<void> => {
   await apiClient.delete(`/board/free/${id}`)
+}
+
+/**
+ * 휴지통. 공지·행사가 CORE 이상인 것과 달리 MEMBER 이상이면 부를 수 있다 —
+ * 자유게시판은 MEMBER 도 글을 쓰므로 자기가 지운 글을 본인이 되살릴 수 있어야 한다.
+ * ORGANIZER 미만에게는 서버가 자기 글만 걸러서 준다.
+ */
+export const fetchDeletedFreePosts = async (
+  params: { page?: number; size?: number },
+  client: AxiosInstance
+): Promise<PagedResult<DeletedFreeBoardSummary>> => {
+  const response = await client.get('/board/free/deleted', {
+    params: { page: params.page ?? 0, size: params.size ?? 15 }
+  })
+  return unwrapPaged<DeletedFreeBoardSummary>(response.data)
+}
+
+export const restoreFreePost = async (apiClient: AxiosInstance, id: number): Promise<void> => {
+  await apiClient.post(`/board/free/${id}/restore`)
+}
+
+/**
+ * 댓글 목록. 페이지네이션이 없어 트리 전체가 한 번에 온다.
+ *
+ * 여기서도 unwrapApiResponse 를 쓰지 않는다 — 댓글에 'content' 필드가 있어
+ * WRAPPER_KEYS 의 'content' 와 부딪힌다.
+ */
+export const fetchFreeComments = async (
+  postId: number,
+  client: AxiosInstance
+): Promise<FreeBoardComment[]> => {
+  const response = await client.get(`/board/free/${postId}/comments`)
+  return unwrapOnce<FreeBoardComment[]>(response.data)
+}
+
+export const createFreeComment = async (
+  apiClient: AxiosInstance,
+  postId: number,
+  payload: { content: string; parentId?: number }
+): Promise<number> => {
+  const response = await apiClient.post(`/board/free/${postId}/comments`, payload)
+  return unwrapOnce<number>(response.data)
+}
+
+/** 수정·삭제는 글 id 없이 댓글 id 만으로 부른다. */
+export const updateFreeComment = async (
+  apiClient: AxiosInstance,
+  commentId: number,
+  content: string
+): Promise<void> => {
+  await apiClient.patch(`/board/free/comments/${commentId}`, { content })
+}
+
+export const deleteFreeComment = async (
+  apiClient: AxiosInstance,
+  commentId: number
+): Promise<void> => {
+  await apiClient.delete(`/board/free/comments/${commentId}`)
 }

--- a/src/services/board/noticeClient.ts
+++ b/src/services/board/noticeClient.ts
@@ -1,13 +1,14 @@
 import type { AxiosInstance } from 'axios'
 
 import type {
+  DeletedNoticeSummary,
   NoticeCreatePayload,
   NoticeDetail,
   NoticeSearchType,
   NoticeSummary,
   NoticeUpdatePayload
 } from '@/types/notice'
-import type { PageMeta } from '@/utils/api/unwrapPaged'
+import { unwrapPaged, type PagedResult, type PageMeta } from '@/utils/api/unwrapPaged'
 
 export interface FetchNoticeListParams {
   page?: number
@@ -91,6 +92,21 @@ export const updateNotice = async (
 
 export const deleteNotice = async (apiClient: AxiosInstance, id: number): Promise<void> => {
   await apiClient.delete(`/board/notices/${id}`)
+}
+
+/** 휴지통. CORE 이상 전용이고, ORGANIZER 미만에게는 서버가 자기 글만 걸러서 준다. */
+export const fetchDeletedNotices = async (
+  params: { page?: number; size?: number },
+  client: AxiosInstance
+): Promise<PagedResult<DeletedNoticeSummary>> => {
+  const response = await client.get('/board/notices/deleted', {
+    params: { page: params.page ?? 0, size: params.size ?? 15 }
+  })
+  return unwrapPaged<DeletedNoticeSummary>(response.data)
+}
+
+export const restoreNotice = async (apiClient: AxiosInstance, id: number): Promise<void> => {
+  await apiClient.post(`/board/notices/${id}/restore`)
 }
 
 /** GET /pinned는 ORGANIZER+ 전용이라 apiClient가 필수다. */

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -59,6 +59,16 @@ export interface EventBoardDetail {
   updatedAt: string
 }
 
+/** 휴지통 한 행. deletedAt 이 정렬 기준이라 목록에도 보여준다. */
+export interface DeletedEventBoardSummary {
+  id: number
+  title: string
+  eventStartDate: string
+  eventEndDate: string
+  organizingTeam: TeamValue
+  deletedAt: string
+}
+
 export interface EventBoardCreatePayload {
   title: string
   eventStartDate: string

--- a/src/types/free.ts
+++ b/src/types/free.ts
@@ -30,6 +30,16 @@ export interface FreeBoardDetail {
   updatedAt: string
 }
 
+/** 휴지통 한 행. deletedAt 이 정렬 기준이라 목록에도 보여준다. */
+export interface DeletedFreeBoardSummary {
+  id: number
+  title: string
+  authorName: string
+  viewCount: number
+  createdAt: string
+  deletedAt: string
+}
+
 export interface FreeBoardCreatePayload {
   title: string
   content: string
@@ -38,3 +48,21 @@ export interface FreeBoardCreatePayload {
 
 /** FreeBoardUpdateRequest는 전 필드 선택이고 null인 필드는 바꾸지 않는다. */
 export type FreeBoardUpdatePayload = Partial<FreeBoardCreatePayload>
+
+/**
+ * 댓글 한 건. 대댓글은 1단계까지라 replies 안에는 replies 가 비어 있다.
+ *
+ * 삭제된 댓글은 대댓글이 남아 있을 때만 내려온다. 그때 content·authorId·authorName 이
+ * 전부 null 이고 deleted 가 true 다 — 화면 문구는 우리가 정한다.
+ */
+export interface FreeBoardComment {
+  id: number
+  parentId: number | null
+  content: string | null
+  authorId: number | null
+  authorName: string | null
+  deleted: boolean
+  createdAt: string
+  updatedAt: string
+  replies: FreeBoardComment[]
+}

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -32,12 +32,26 @@ export interface NoticeDetail {
   category: NoticeCategory
   title: string
   content: string
+  /** 수정·삭제가 '본인 또는 ORGANIZER+'라 화면이 본인 여부를 판정하려면 필요하다. */
+  authorId: number
   authorName: string
   viewCount: number
   isPublished: boolean
   attachments: AttachmentResponse[]
   createdAt: string
   updatedAt: string
+}
+
+/** 휴지통 한 행. deletedAt 이 정렬 기준이라 목록에도 보여준다. */
+export interface DeletedNoticeSummary {
+  id: number
+  category: NoticeCategory
+  title: string
+  authorName: string
+  viewCount: number
+  isPublished: boolean
+  createdAt: string
+  deletedAt: string
 }
 
 export interface NoticeCreatePayload {


### PR DESCRIPTION
서버 PR [Server#340](https://github.com/GDGoCINHA/24-2_GDGoC_Server/pull/340) 과 짝이다. **서버를 먼저 올려야 한다.**

## 1. 휴지통 화면 3종

`/board/events/trash`, `/board/notices/trash`, `/board/free/trash`

**서버 API 는 원래 있었는데 화면이 없었다.** 삭제한 글을 되살릴 수단이 아예 없어서 DB 를 직접 만져야 했다. (자유게시판 API 는 이번에 서버에 추가됐다.)

목록 페이지에 진입 버튼도 붙였다. 노출 조건은 서버 경계와 같다 — 행사·공지는 CORE+, 자유게시판은 MEMBER+.

**운영진이 아니면 서버가 목록을 걸러서 준다.** 자기 것만 보이는 걸 "비어 있다"로 오해하지 않도록 화면에 적었다. 기준이 게시판마다 다르다.

| 게시판 | ORGANIZER 미만에게 보이는 것 |
|---|---|
| 공지·자유 | 본인이 삭제한 글 |
| 행사 | 소속 팀이 주최한 행사 (`requireTeamAccess`) |

## 2. 자유게시판 댓글·대댓글

**대댓글은 1단계까지다.** 대댓글에도 '답글'을 띄우지만 서버가 같은 최상위 댓글에 붙이므로 깊이는 늘지 않는다. 사용자가 깊이를 신경 쓸 필요가 없다.

**삭제된 댓글**은 대댓글이 남아 있을 때만 내려오고, 그때 '삭제된 댓글입니다'로 자리를 남긴다. 서버가 `content`·`authorId`·`authorName` 을 전부 `null` 로 주므로 화면이 지운 사람을 알 수 없다.

수정·삭제 버튼은 서버 규칙(`requireAuthorOrOrganizer`)과 같은 조건으로 띄운다.

## 3. 행사·공지 수정·삭제 버튼 판정 (기존 결함)

전에는 **CORE 이상 전원에게 버튼을 보여주고 거부는 403 에 맡겼다.** 서버 규칙이 게시판마다 다른데 화면이 그걸 표현할 값을 못 받았기 때문이다.

| 게시판 | 서버의 실제 규칙 | 판정에 쓰는 값 |
|---|---|---|
| 공지 | 본인 또는 ORGANIZER+ | `authorId` — 서버가 이번에 주기 시작 |
| 행사 | 주최 팀 일치 또는 ORGANIZER+ | `organizingTeam` — **원래 응답에 있었다** |

행사는 `authorId` 가 애초에 답이 아니었다. 그래서 서버에도 넣지 않았다.

상세뿐 아니라 **수정 페이지에도 같은 판정을 건다.** URL 로 직접 들어오면 폼이 열린 뒤 저장할 때야 403 을 만나기 때문이다.

## 검증

```
npx --yes yarn@1.22.22 build   # Done in 27.05s
```

- 새 라우트 3개(`/board/*/trash`)가 정적 생성됐다
- 이번에 추가·수정한 파일에서 lint 경고 없음

**브라우저로 눌러보지 못했다.** 댓글·휴지통·권한 판정 모두 로그인이 필요한데, 나는 계정으로 로그인하지 않는다. 특히 확인이 필요한 것:

- 행사 상세에서 **주최 팀 소속 CORE 에게 수정·삭제 버튼이 뜨는지.** `user.team` 이 로그인 응답에 실제로 채워지는지에 달려 있다. 비어 있으면 ORGANIZER 가 아닌 사람에게 버튼이 사라진다(서버 규칙과는 일치하지만, 저장된 값이 낡았다면 과하게 막는 셈이다)
- 대댓글의 답글이 같은 최상위 댓글에 붙는지
- 휴지통 복원 후 목록에서 사라지는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug7rbkpZ4cgNgECyv1GEXn
