### PR TITLE
fix: 상단 고정 모달의 저장 버튼이 화면 밖으로 밀리지 않게 한다

### DIFF
--- a/src/components/board/PinnedNoticeModal.tsx
+++ b/src/components/board/PinnedNoticeModal.tsx
@@ -130,109 +130,123 @@ export function PinnedNoticeModal({ open, apiClient, onClose, onSaved }: PinnedN
       aria-modal="true"
       aria-label="상단 고정 관리"
     >
-      <div className="flex max-h-[85vh] w-full max-w-[640px] flex-col gap-4 overflow-y-auto rounded-2xl border border-gray-800 bg-black p-6 text-white">
-        <div className="flex items-center justify-between">
+      {/* 카드 전체를 스크롤시키면 후보 10개에 밀려 아래쪽 "저장"이 화면 밖으로 나간다.
+          그러면 위쪽 "닫기"만 보여서 저장하지 않고 닫게 된다. 가운데만 스크롤한다. */}
+      <div className="flex max-h-[85vh] w-full max-w-[640px] flex-col gap-4 overflow-hidden rounded-2xl border border-gray-800 bg-black p-6 text-white">
+        <div className="flex shrink-0 items-center justify-between">
           <h2 className="typo-pc-s2 mobile:typo-m-s2">상단 고정 관리</h2>
           <button type="button" onClick={onClose} className="text-gray-500 hover:text-white">
             닫기
           </button>
         </div>
 
-        <section className="flex flex-col gap-2">
-          <p className="text-gray-500 typo-pc-c1 mobile:typo-m-c1">
-            현재 고정 {selected.length}/{MAX_PINNED} — 드래그해 순서를 바꿉니다.
-          </p>
-          {loading ? (
-            <p className="py-6 text-center text-gray-500 typo-pc-b3 mobile:typo-m-b3">불러오는 중...</p>
-          ) : selected.length === 0 ? (
-            <p className="py-6 text-center text-gray-500 typo-pc-b3 mobile:typo-m-b3">고정된 공지가 없습니다.</p>
-          ) : (
-            <Reorder.Group
-              axis="y"
-              values={selected}
-              onReorder={setSelected}
-              className="flex flex-col gap-2"
-            >
-              {selected.map((notice, index) => (
-                <Reorder.Item key={notice.id} value={notice}>
-                  <div className="flex cursor-grab items-center gap-3 rounded-lg bg-gray-100 px-4 py-2 typo-pc-b3 mobile:typo-m-b3">
-                    <span className="shrink-0 text-gray-700">{index + 1}</span>
+        {/* min-h-0 이 없으면 flex 아이템의 min-height:auto 때문에 줄어들지 않아 스크롤이 안 생긴다. */}
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
+          <section className="flex flex-col gap-2">
+            <p className="text-gray-500 typo-pc-c1 mobile:typo-m-c1">
+              현재 고정 {selected.length}/{MAX_PINNED} — 드래그해 순서를 바꿉니다.
+            </p>
+            {loading ? (
+              <p className="py-6 text-center text-gray-500 typo-pc-b3 mobile:typo-m-b3">
+                불러오는 중...
+              </p>
+            ) : selected.length === 0 ? (
+              <p className="py-6 text-center text-gray-500 typo-pc-b3 mobile:typo-m-b3">
+                고정된 공지가 없습니다.
+              </p>
+            ) : (
+              <Reorder.Group
+                axis="y"
+                values={selected}
+                onReorder={setSelected}
+                className="flex flex-col gap-2"
+              >
+                {selected.map((notice, index) => (
+                  <Reorder.Item key={notice.id} value={notice}>
+                    <div className="flex cursor-grab items-center gap-3 rounded-lg bg-gray-100 px-4 py-2 typo-pc-b3 mobile:typo-m-b3">
+                      <span className="shrink-0 text-gray-700">{index + 1}</span>
+                      <NoticeCategoryTag category={notice.category} />
+                      <span className="flex-1 truncate">{notice.title}</span>
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(notice.id)}
+                        className="shrink-0 underline"
+                      >
+                        빼기
+                      </button>
+                    </div>
+                  </Reorder.Item>
+                ))}
+              </Reorder.Group>
+            )}
+          </section>
+
+          <section className="flex flex-col gap-2 border-t border-gray-800 pt-4">
+            <p className="text-gray-500 typo-pc-c1 mobile:typo-m-c1">
+              고정할 공지 찾기 (공개된 공지만 고정할 수 있습니다)
+            </p>
+            {/* device 기본값 'pc' 는 w-280(=1120px) 고정폭이라 640px 모달을 넘긴다.
+              좁은 화면에서는 더 심하다. pc/mobile 을 각각 렌더하고 CSS 로 감춘다. */}
+            {(['pc', 'mobile'] as const).map((device) => (
+              <GdgSearchField
+                key={device}
+                device={device}
+                // pc 는 half(412px)면 640px 모달에 들어간다. mobile 은 half 가 w-fit 으로
+                // 떨어져 입력칸이 글자 폭만큼 쪼그라들므로 full(343px)을 쓴다.
+                width={device === 'pc' ? 'half' : 'full'}
+                className={device === 'pc' ? 'hidden pc:flex' : 'flex pc:hidden'}
+                value={keyword}
+                onChange={(event) => setKeyword(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault()
+                    setSubmittedKeyword(keyword)
+                  }
+                }}
+                placeholder="제목·내용으로 검색"
+              />
+            ))}
+            <ul className="flex flex-col gap-1">
+              {candidates.map((notice) => {
+                const alreadySelected = selected.some((item) => item.id === notice.id)
+                return (
+                  <li
+                    key={notice.id}
+                    className="flex items-center gap-3 border-b border-gray-800 px-1 py-2 typo-pc-b3 mobile:typo-m-b3"
+                  >
                     <NoticeCategoryTag category={notice.category} />
                     <span className="flex-1 truncate">{notice.title}</span>
                     <button
                       type="button"
-                      onClick={() => handleRemove(notice.id)}
-                      className="shrink-0 underline"
+                      onClick={() => handleAdd(notice)}
+                      disabled={alreadySelected || isFull}
+                      className="shrink-0 underline disabled:opacity-30"
                     >
-                      빼기
+                      {alreadySelected ? '고정됨' : '추가'}
                     </button>
-                  </div>
-                </Reorder.Item>
-              ))}
-            </Reorder.Group>
-          )}
-        </section>
-
-        <section className="flex flex-col gap-2 border-t border-gray-800 pt-4">
-          <p className="text-gray-500 typo-pc-c1 mobile:typo-m-c1">
-            고정할 공지 찾기 (공개된 공지만 고정할 수 있습니다)
-          </p>
-          {/* device 기본값 'pc' 는 w-280(=1120px) 고정폭이라 640px 모달을 넘긴다.
-              좁은 화면에서는 더 심하다. pc/mobile 을 각각 렌더하고 CSS 로 감춘다. */}
-          {(['pc', 'mobile'] as const).map((device) => (
-            <GdgSearchField
-              key={device}
-              device={device}
-              // pc 는 half(412px)면 640px 모달에 들어간다. mobile 은 half 가 w-fit 으로
-              // 떨어져 입력칸이 글자 폭만큼 쪼그라들므로 full(343px)을 쓴다.
-              width={device === 'pc' ? 'half' : 'full'}
-              className={device === 'pc' ? 'hidden pc:flex' : 'flex pc:hidden'}
-              value={keyword}
-              onChange={(event) => setKeyword(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter') {
-                  event.preventDefault()
-                  setSubmittedKeyword(keyword)
-                }
-              }}
-              placeholder="제목·내용으로 검색"
-            />
-          ))}
-          <ul className="flex flex-col gap-1">
-            {candidates.map((notice) => {
-              const alreadySelected = selected.some((item) => item.id === notice.id)
-              return (
-                <li
-                  key={notice.id}
-                  className="flex items-center gap-3 border-b border-gray-800 px-1 py-2 typo-pc-b3 mobile:typo-m-b3"
-                >
-                  <NoticeCategoryTag category={notice.category} />
-                  <span className="flex-1 truncate">{notice.title}</span>
-                  <button
-                    type="button"
-                    onClick={() => handleAdd(notice)}
-                    disabled={alreadySelected || isFull}
-                    className="shrink-0 underline disabled:opacity-30"
-                  >
-                    {alreadySelected ? '고정됨' : '추가'}
-                  </button>
+                  </li>
+                )
+              })}
+              {candidates.length === 0 && (
+                <li className="py-4 text-center text-gray-500 typo-pc-c1 mobile:typo-m-c1">
+                  검색 결과가 없습니다.
                 </li>
-              )
-            })}
-            {candidates.length === 0 && (
-              <li className="py-4 text-center text-gray-500 typo-pc-c1 mobile:typo-m-c1">검색 결과가 없습니다.</li>
+              )}
+            </ul>
+            {isFull && (
+              <p className="text-gray-500 typo-pc-c1 mobile:typo-m-c1">
+                슬롯이 가득 찼습니다. 추가하려면 먼저 하나를 빼세요.
+              </p>
             )}
-          </ul>
-          {isFull && (
-            <p className="text-gray-500 typo-pc-c1 mobile:typo-m-c1">
-              슬롯이 가득 찼습니다. 추가하려면 먼저 하나를 빼세요.
-            </p>
-          )}
-        </section>
+          </section>
+        </div>
 
-        {errorMessage && <p className="text-red typo-pc-b3 mobile:typo-m-b3">{errorMessage}</p>}
+        {/* 저장 실패 문구는 스크롤 밖에 둔다 — 안에 있으면 스크롤 위치에 따라 안 보인다. */}
+        {errorMessage && (
+          <p className="shrink-0 text-red typo-pc-b3 mobile:typo-m-b3">{errorMessage}</p>
+        )}
 
-        <div className="flex gap-3">
+        <div className="flex shrink-0 gap-3">
           <GdgButton variant="bordered" fullWidth onClick={onClose}>
             취소
           </GdgButton>


### PR DESCRIPTION
## 증상

상단 고정 관리 모달에서 공지를 **추가할 수는 있는데 저장할 방법이 안 보인다.** 위쪽 `닫기`만 보이므로 그걸 누르게 되고, 모달은 저장 전까지 아무 요청도 보내지 않는 설계라 변경이 그대로 사라진다.

## 원인

카드 하나에 `overflow-y-auto` 가 걸려 있어서 **푸터(취소/저장)까지 스크롤 컨텐츠에 포함**된다.

```
max-h-[85vh] ... overflow-y-auto   ← 카드 = 스크롤 컨테이너
```

고정 3개 + 후보 10개(`fetchNoticeList` size=10)면 카드 내용이 859px 이다. `85vh` 가 그보다 작아지는 순간 푸터가 카드 밖으로 밀린다.

## 측정

빌드된 CSS 로 수정 전/후 마크업을 같은 조건(고정 3 + 후보 10)으로 렌더하고 뷰포트 높이를 훑었다.

| 가정 뷰포트 | 카드 높이 제한(85vh) | 수정 전 저장 버튼 | 수정 후 |
|---:|---:|---|---|
| 600 | 510 | ❌ 가려짐 | ✅ |
| 740 | 629 | ❌ 가려짐 | ✅ |
| 860 | 731 | ❌ 가려짐 | ✅ |
| **950** | 808 | ❌ 가려짐 | ✅ |
| 1010 | 859 | ✅ | ✅ |
| 1271 | 1080 | ✅ | ✅ |

경계는 **뷰포트 1010px**. 1920×1080 모니터의 브라우저 뷰포트가 대략 950px 이므로 **일반적인 데스크톱에서 재현된다.** 노트북·모바일은 더 심하다.

## 수정

- 카드를 `overflow-hidden` 으로 바꾸고, 헤더와 푸터 사이에 스크롤 래퍼(`min-h-0 flex-1 overflow-y-auto`)를 넣었다. `min-h-0` 이 없으면 flex 아이템의 `min-height:auto` 때문에 줄어들지 않아 스크롤이 생기지 않는다.
- 저장 실패 문구도 스크롤 밖으로 옮겼다. 안에 있으면 스크롤 위치에 따라 안 보인다.

공백 무시 기준 실질 변경은 21줄 추가 / 7줄 삭제다. 나머지는 한 단계 들여쓰기(prettier).

## 검증

- `yarn build` EXIT=0
- `next lint` 해당 파일 경고 0
- 위 표의 뷰포트 스윕

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug7rbkpZ4cgNgECyv1GEXn
