### PR TITLE
fix: 상단 고정 모달의 저장 버튼이 카드 밖으로 밀려나지 않게 한다

### DIFF
--- a/src/components/board/PinnedNoticeModal.tsx
+++ b/src/components/board/PinnedNoticeModal.tsx
@@ -246,13 +246,20 @@ export function PinnedNoticeModal({ open, apiClient, onClose, onSaved }: PinnedN
           <p className="shrink-0 text-red typo-pc-b3 mobile:typo-m-b3">{errorMessage}</p>
         )}
 
+        {/* GdgButton 은 기본 클래스에 shrink-0 이 있고 fullWidth 는 w-full 을 준다.
+            둘을 한 행에 나란히 두면 각각 100% 폭을 요구하면서 줄어들지도 못해
+            행이 두 배로 넘치고 "저장"이 카드 밖으로 밀려난다. 감싸는 쪽에서 반씩 나눈다. */}
         <div className="flex shrink-0 gap-3">
-          <GdgButton variant="bordered" fullWidth onClick={onClose}>
-            취소
-          </GdgButton>
-          <GdgButton variant="active" fullWidth onClick={handleSave} loading={saving}>
-            저장
-          </GdgButton>
+          <div className="min-w-0 flex-1">
+            <GdgButton variant="bordered" fullWidth onClick={onClose}>
+              취소
+            </GdgButton>
+          </div>
+          <div className="min-w-0 flex-1">
+            <GdgButton variant="active" fullWidth onClick={handleSave} loading={saving}>
+              저장
+            </GdgButton>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
#351 의 후속. **#351 은 원인을 잘못 짚었다.**

## 실제 원인 — 세로가 아니라 가로

`GdgButton` 은 기본 클래스에 `shrink-0` 이 있고(`GdgButton.tsx:105`) `fullWidth` 는 `w-full` 을 준다(`:96-97`). 한 행에 둘을 나란히 두면 **각각 100% 폭을 요구하면서 줄어들지도 못한다.**

dev 에서 실측:

```
푸터 보이는 폭   590px
푸터 실제 내용폭 1191px      ← 590 + gap 12 + 590
취소 right 1895 / 카드 right 1920
저장            카드 밖 (화면에 빨간 조각만 걸침)
```

그래서 "저장" 버튼이 아예 안 보이고, 위쪽 `닫기`를 누르게 되어 변경이 사라진다.

## 수정

각 버튼을 `min-w-0 flex-1` 로 감싸 행을 반씩 나눈다. `flex-1` 을 버튼 className 에 직접 주지 않은 이유는 `shrink-0` 과 충돌해 CSS 소스 순서에 결과가 좌우되기 때문이다. 감싸는 쪽에서 나누면 확정적이다.

## 검증 (dev 실제 화면, ORGANIZER 세션)

적용 후 실측:

| | 폭 | 카드 안 | 글자 잘림 |
|---|---:|---|---|
| 취소 | 289px | ✅ | 없음 |
| 저장 | 289px | ✅ | 없음 |

푸터 내용 폭 590 = 보이는 폭 590, 가로 넘침 해소.

- `yarn build` EXIT=0 / `next lint` 경고 0 / prettier 통과

## #351 은 왜 남겨두나

#351 의 세로 스크롤 수정(카드 `overflow-hidden` + 가운데만 스크롤)은 **별개의 실재하는 문제**다. 고정 3 + 후보 10이면 카드 내용이 859px 이라 뷰포트 1010px 미만에서 푸터가 세로로 밀린다. 지금은 dev 에 공지가 2건뿐이라 드러나지 않을 뿐이고, 공지가 늘면 발생한다.

다만 #351 이 `overflow-y-auto` → `overflow-hidden` 으로 바꾸면서 **가로도 hidden 이 되어 이 증상을 더 확실히 가렸다.** 이전에는 가로 스크롤로 저장에 도달할 여지가 있었다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug7rbkpZ4cgNgECyv1GEXn
