### PR TITLE
release: 코어 모집 일정 갱신 · 부원 학기 필터

### DIFF
--- a/src/app/dashboard/members/page.tsx
+++ b/src/app/dashboard/members/page.tsx
@@ -70,6 +70,32 @@ const PAY_SEGMENTS = [
   { label: '입금 완료', value: true }
 ] as const
 
+// 서버 AdmissionSemester enum 과 값을 맞춘다. 목록에 없는 값을 보내면 400 이 난다.
+const SEMESTER_OPTIONS = [
+  'Y29_2', 'Y29_1', 'Y28_2', 'Y28_1', 'Y27_2', 'Y27_1',
+  'Y26_2', 'Y26_1', 'Y25_2', 'Y25_1', 'Y24_2', 'Y24_1',
+  'Y23_2', 'Y23_1', 'Y22_2', 'Y22_1', 'Y21_2'
+] as const
+
+const ALL_SEMESTERS = 'ALL'
+
+/** 서버 SemesterCalculator 와 같은 규칙 — 1월은 직전 해 2학기, 2~7월 1학기, 8~12월 2학기. */
+function currentAdmissionSemester(): string {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = now.getMonth() + 1
+  const yy = month === 1 ? (year - 1) % 100 : year % 100
+  const term = month === 1 ? 2 : month <= 7 ? 1 : 2
+  return `Y${String(yy).padStart(2, '0')}_${term}`
+}
+
+/** 'Y26_2' → '2026-2학기' */
+function formatSemesterLabel(value?: string | null): string {
+  if (!value) return '-'
+  const matched = /^Y(\d{2})_(\d)$/.exec(value)
+  return matched ? `20${matched[1]}-${matched[2]}학기` : value
+}
+
 const SEGMENT_WIDTH_PX = Math.max(...PAY_SEGMENTS.map((item) => item.label.length * 16 + 26))
 
 export default function DashboardMembersPage() {
@@ -81,6 +107,8 @@ export default function DashboardMembersPage() {
 
   const [searchInput, setSearchInput] = useState('')
   const [question, setQuestion] = useState('')
+  // 모집 기간에는 이번 학기 지원자만 보는 게 기본이다. 과거 기수는 드롭다운으로 전환한다.
+  const [semester, setSemester] = useState<string>(currentAdmissionSemester())
   const [page, setPage] = useState(1)
   const [size] = useState(20)
   const [totalPages, setTotalPages] = useState(1)
@@ -100,7 +128,8 @@ export default function DashboardMembersPage() {
           size,
           sort: 'createdAt',
           dir: 'DESC',
-          ...(question.trim() ? { question: question.trim() } : {})
+          ...(question.trim() ? { question: question.trim() } : {}),
+          ...(semester !== ALL_SEMESTERS ? { admissionSemester: semester } : {})
         }
       })
 
@@ -118,7 +147,7 @@ export default function DashboardMembersPage() {
     } finally {
       setLoading(false)
     }
-  }, [apiClient, page, question, size])
+  }, [apiClient, page, question, semester, size])
 
   useEffect(() => {
     void fetchMembers()
@@ -161,6 +190,13 @@ export default function DashboardMembersPage() {
       setLoading(false)
     }
   }
+
+  // 아직 오지 않은 학기는 고를 이유가 없다. 현재 학기부터 과거만 남긴다.
+  const semesterOptions = useMemo(() => {
+    const current = currentAdmissionSemester()
+    const index = SEMESTER_OPTIONS.indexOf(current as (typeof SEMESTER_OPTIONS)[number])
+    return index >= 0 ? SEMESTER_OPTIONS.slice(index) : SEMESTER_OPTIONS
+  }, [])
 
   const pageNumbers = useMemo(() => {
     const maxVisible = 7
@@ -211,6 +247,21 @@ export default function DashboardMembersPage() {
             </Link>
           </div>
           <div className="flex w-full gap-2 pc:w-auto">
+            <select
+              value={semester}
+              onChange={(e) => {
+                setPage(1)
+                setSemester(e.target.value)
+              }}
+              className="h-11 rounded-lg border border-gray-300 bg-gray-100 px-3 text-white outline-none focus:border-white"
+            >
+              <option value={ALL_SEMESTERS}>전체 학기</option>
+              {semesterOptions.map((option) => (
+                <option key={option} value={option}>
+                  {formatSemesterLabel(option)}
+                </option>
+              ))}
+            </select>
             <input
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
@@ -249,6 +300,7 @@ export default function DashboardMembersPage() {
                 <th className="px-4 py-3 typo-pc-b3 text-gray-700">이름</th>
                 <th className="px-4 py-3 typo-pc-b3 text-gray-700">학과</th>
                 <th className="px-4 py-3 typo-pc-b3 text-gray-700">학번</th>
+                <th className="px-4 py-3 typo-pc-b3 text-gray-700">지원 학기</th>
                 <th className="px-4 py-3 typo-pc-b3 text-gray-700">전화번호</th>
                 <th className="px-4 py-3 typo-pc-b3 text-gray-700">회비</th>
                 <th className="px-4 py-3 typo-pc-b3 text-gray-700">상세</th>
@@ -257,7 +309,7 @@ export default function DashboardMembersPage() {
             <tbody>
               {members.length === 0 ? (
                 <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center typo-pc-b3 text-gray-700">
+                  <td colSpan={7} className="px-4 py-8 text-center typo-pc-b3 text-gray-700">
                     조회된 지원자가 없습니다.
                   </td>
                 </tr>
@@ -267,6 +319,9 @@ export default function DashboardMembersPage() {
                     <td className="px-4 py-3 typo-pc-b3">{member.name}</td>
                     <td className="px-4 py-3 typo-pc-b3">{formatMajorLabel(member.major)}</td>
                     <td className="px-4 py-3 typo-pc-b3">{member.studentId}</td>
+                    <td className="px-4 py-3 typo-pc-b3">
+                      {formatSemesterLabel(member.admissionSemester)}
+                    </td>
                     <td className="px-4 py-3 typo-pc-b3">
                       {formatPhoneNumberDisplay(member.phoneNumber)}
                     </td>

--- a/src/constant/recruitSchedule.ts
+++ b/src/constant/recruitSchedule.ts
@@ -41,11 +41,11 @@ export function formatKoreanPeriodShort(openAt: string, closeAt: string): string
 export const CORE_SCHEDULE = {
   /** 서버 응답을 못 받았을 때만 쓰는 대체값. 서버 설정(app.recruit.core.*)과 함께 고친다. */
   fallbackOpenAt: '2026-08-10T00:00:00+09:00',
-  fallbackCloseAt: '2026-08-30T23:59:59+09:00',
-  documentResult: '~ 2026. 8. 31.(월)',
-  interview: '2026. 9. 1.(화) - 2026. 9. 5.(토)',
+  fallbackCloseAt: '2026-08-23T23:59:59+09:00',
+  documentResult: '2026. 8. 23.(일)',
+  interview: '2026. 8. 24.(월) - 2026. 8. 30.(일)',
   interviewNote: '※ 지원자 및 면접관 일정에 따라 마감 전 면접이 가능할 수 있습니다.',
-  finalResult: '~ 2026. 9. 6.(일)',
+  finalResult: '2026. 8. 31.(월)',
   meetingNote: '※ 일정은 9월 내로 공지 드립니다.'
 } as const
 


### PR DESCRIPTION
## 포함 커밋

| 커밋 | 내용 |
|---|---|
| `928c829` | 코어 모집 일정을 확정 일정으로 갱신 |
| `a365801` | 부원 지원자 목록 학기 드롭다운 + 지원 학기 컬럼 |

## 코어 일정 갱신

서류 8/10(월)~**8/23(일)**, 서류 결과 8/23(일), 면접 8/24(월)~8/30(일), 최종 8/31(월).

기존 값은 마감 8/30, 면접 9/1~9/5, 최종 9/6 이었다. 모집 안내 화면(`RecruitScheduleCard`)이
이 상수를 그대로 보여주므로 지원자에게 잘못된 일정이 노출되던 상태였다.

서버 `application-prod.yml` 의 `app.recruit.core.close-at` 도 8/23 으로 함께 맞췄다.

## 부원 학기 필터

역대 지원자가 한 목록에 섞여 나왔다. 학기 드롭다운을 추가하고 **기본값을 현재 학기**로 뒀다
(코어 지원서 화면도 현재 세션을 기본으로 연다). 필터 결과를 눈으로 확인할 수 있도록 지원 학기
컬럼도 붙였다.

학기 계산은 서버 `SemesterCalculator` 와 같은 규칙을 쓰고, 선택지는 `AdmissionSemester` enum 과
값을 맞췄다. 아직 오지 않은 학기는 감춘다.

## 배포 순서

**서버 PR(#344)을 먼저 머지해야 한다.** 이 변경은 서버가 `admissionSemester` 파라미터를 받고
목록 응답에 같은 필드를 실어 보내는 것을 전제로 한다.

## 검증

- `yarn build` 성공 (배포와 동일 경로, `yarn.lock` 변화 없음)
- 개발 서버 반영 확인 — 청크에서 새 문자열 확인, 서버 API 파라미터 수용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHxirdfnN9Wxrt9UHzBqVd