### PR TITLE
행사게시판 업로드 수정과 썸네일·본문 이미지 정리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,11 @@
 
 - 커밋 메시지는 conventional commits를 따른다 (`feat:`, `fix:`, `refactor:`, `chore:`).
 - 브랜치는 `feature/{기능}` → `develop` → `master` 순으로 올린다.
-- 코드 스타일은 Prettier가 강제한다. 수정 후 `yarn format`을 실행한다.
+- 코드 스타일은 Prettier가 강제한다. 단 **`yarn format`은 쓰지 마라** — 아래 함정 참고. 만진 파일만 지정해 돌린다.
+
+```bash
+npx --yes yarn@1.22.22 prettier --write src/app/board/events/new/page.tsx
+```
 
 ## 명령어
 
@@ -35,8 +39,8 @@
 yarn dev            # 개발 서버
 yarn build          # 정적 빌드 (out/ 생성)
 yarn lint           # ESLint
-yarn format         # Prettier 적용
-yarn format:check   # 포맷 검사만
+yarn format         # ⚠️ 리포 전체 재포맷 — 쓰지 마라 (아래 함정)
+yarn format:check   # 포맷 검사만 (읽기 전용이라 안전)
 ```
 
 **테스트 스크립트는 없다.** 테스트 인프라가 구성돼 있지 않으므로 검증은 `yarn build`와 수동 확인에 의존한다.
@@ -61,6 +65,21 @@ yarn format:check   # 포맷 검사만
 ```bash
 git log --oneline origin/develop..origin/master
 ```
+
+### `yarn format`은 리포 전체를 재포맷한다
+
+이 리포는 Prettier 기준으로 정리된 적이 **없다.** 그래서 `yarn format`을 한 번 돌리면 변경 파일이 아니라 **260여 개 파일이 수정되고** diff가 통째로 오염된다. 만진 파일만 지정해 돌려라.
+
+이미 돌려버렸다면 — **`git status`가 거짓말을 한다.** `core.autocrlf=true`인데 Prettier가 LF로 다시 쓰므로, `git checkout -- .`로 내용을 복원해도 워킹트리는 LF로 남아 100개 넘는 파일이 `M`으로 보인다. 판정은 **`git diff --stat`으로 한다** — EOL만 다른 파일은 blob이 같아 커밋에 들어가지 않는다. 커밋을 마친 뒤 `git checkout -- .`을 한 번 더 돌리면 EOL까지 정리된다.
+
+되돌릴 때 내 변경만 남기는 필터:
+
+```bash
+KEEP="src/a.ts|src/b.tsx"
+git diff --name-only -z | grep -zvE "^($KEEP)$" | xargs -0 --no-run-if-empty git checkout --
+```
+
+이 필터는 **파일 단위**라, 만진 파일 *안에* 섞인 무관한 재배치(JSX 줄바꿈 등)는 안 지워진다. 커밋 전에 `git diff --cached`를 눈으로 읽는 수밖에 없다.
 
 ---
 

--- a/src/app/board/events/detail/page.tsx
+++ b/src/app/board/events/detail/page.tsx
@@ -1,12 +1,12 @@
 'use client'
 
 import axios from 'axios'
-import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 
 import { AttachmentList } from '@/components/board/AttachmentList'
+import { BoardContent } from '@/components/board/BoardContent'
 import { GdgSiteHeader } from '@/components/ui/design-system'
 import { BOARD_MENUS } from '@/components/board/boardMenus'
 import { useAuth } from '@/hooks/useAuth'
@@ -152,15 +152,16 @@ export default function EventBoardDetailPage() {
           </div>
         </div>
 
-        {detail.thumbnailUrl && (
-          <div className="relative h-64 w-full overflow-hidden rounded-2xl bg-gray-100">
-            <Image src={detail.thumbnailUrl} alt="" fill className="object-cover" />
+        {/* 썸네일은 목록에서 글을 고를 때 쓰는 그림이다. 상세에서 또 띄우면 본문에 같은
+            이미지를 넣었을 때 두 번 보인다 — 본문에 넣을 그림은 본문이 갖는다. */}
+        <BoardContent content={detail.content} />
+
+        {detail.attachments.length > 0 && (
+          <div className="space-y-2 border-t border-gray-800 pt-6">
+            <p className="typo-pc-s3 mobile:typo-m-s3 uppercase tracking-[0.2em] text-white/80">첨부</p>
+            <AttachmentList attachments={detail.attachments} />
           </div>
         )}
-
-        <p className="whitespace-pre-wrap typo-pc-b2 mobile:typo-m-b2">{detail.content}</p>
-
-        <AttachmentList attachments={detail.attachments} />
 
         {canManage && (
           <div className="flex gap-3 border-t border-gray-800 pt-6">

--- a/src/app/board/events/edit/page.tsx
+++ b/src/app/board/events/edit/page.tsx
@@ -3,7 +3,14 @@
 import axios from 'axios'
 import Image from 'next/image'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useCallback, useEffect, useRef, useState, type ChangeEvent } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type ClipboardEvent
+} from 'react'
 
 import { AttachmentUploader, type AttachmentDraft } from '@/components/board/AttachmentUploader'
 import {
@@ -83,17 +90,21 @@ export default function EventBoardEditPage() {
   const thumbnailInputRef = useRef<HTMLInputElement | null>(null)
 
   const [contentImageUploading, setContentImageUploading] = useState(false)
-  const contentImageInputRef = useRef<HTMLInputElement | null>(null)
-  const contentRef = useRef<HTMLTextAreaElement | null>(null)
 
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  const handleContentImageSelect = useCallback(
-    async (event: ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0]
-      event.target.value = ''
+  const handleContentPaste = useCallback(
+    async (event: ClipboardEvent<HTMLTextAreaElement>) => {
+      const file = Array.from(event.clipboardData.files).find((item) =>
+        item.type.startsWith('image/')
+      )
+      // 이미지가 아니면 손대지 않는다 — 평범한 텍스트 붙여넣기가 그대로 동작해야 한다.
       if (!file) return
+
+      // 붙여넣은 시점의 자리를 잡아 둔다. 업로드를 기다리는 사이 커서가 움직일 수 있다.
+      const { selectionStart, selectionEnd } = event.currentTarget
+      event.preventDefault()
 
       const sizeError = validateUploadSize(file)
       if (sizeError) {
@@ -108,7 +119,7 @@ export default function EventBoardEditPage() {
         await uploadFileToS3(uploadUrl, file)
         // 본문에는 서명이 붙지 않은 주소를 남긴다. presigned URL 은 5분이면 만료된다.
         const markup = `![](${toPublicUrl(uploadUrl)})`
-        setContent((prev) => insertAtCursor(contentRef.current, prev, markup))
+        setContent((prev) => insertAtCursor(prev, selectionStart, selectionEnd, markup))
       } catch (err) {
         setErrorMessage(describeUploadError(err))
       } finally {
@@ -350,29 +361,17 @@ export default function EventBoardEditPage() {
 
         <div className="flex flex-col gap-2">
           <GdgTextarea
-            ref={contentRef}
             label="내용"
             fullWidth
             rows={10}
             value={content}
             onChange={(event) => setContent(event.target.value)}
+            onPaste={handleContentPaste}
           />
-          <input
-            ref={contentImageInputRef}
-            type="file"
-            accept="image/*"
-            className="hidden"
-            onChange={handleContentImageSelect}
-          />
-          <GdgButton
-            variant="bordered"
-            onClick={() => contentImageInputRef.current?.click()}
-            disabled={contentImageUploading}
-          >
-            {contentImageUploading ? '업로드 중...' : '본문에 이미지 삽입'}
-          </GdgButton>
           <p className="typo-pc-c1 mobile:typo-m-c1 text-gray-500">
-            커서 자리에 <code>![](주소)</code> 가 들어갑니다. 그 자리에 이미지가 표시됩니다.
+            {contentImageUploading
+              ? '이미지 올리는 중...'
+              : '이미지를 복사해 붙여넣으면 그 자리에 들어갑니다.'}
           </p>
         </div>
 

--- a/src/app/board/events/edit/page.tsx
+++ b/src/app/board/events/edit/page.tsx
@@ -21,11 +21,13 @@ import { fetchEventDetail, updateEvent } from '@/services/board/boardClient'
 import {
   describeUploadError,
   requestPresignedUpload,
+  toPublicUrl,
   uploadFileToS3,
   validateUploadSize
 } from '@/services/board/uploadClient'
 import type { AttachmentResponse, EventOrganizingTeam } from '@/types/board'
 import { hasAtLeast } from '@/utils/auth/role'
+import { insertAtCursor } from '@/utils/insertAtCursor'
 
 const TEAM_OPTIONS: GdgDropdownOption[] = [
   { id: 'HQ', label: 'HQ' },
@@ -80,8 +82,41 @@ export default function EventBoardEditPage() {
   const [thumbnailUploading, setThumbnailUploading] = useState(false)
   const thumbnailInputRef = useRef<HTMLInputElement | null>(null)
 
+  const [contentImageUploading, setContentImageUploading] = useState(false)
+  const contentImageInputRef = useRef<HTMLInputElement | null>(null)
+  const contentRef = useRef<HTMLTextAreaElement | null>(null)
+
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const handleContentImageSelect = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0]
+      event.target.value = ''
+      if (!file) return
+
+      const sizeError = validateUploadSize(file)
+      if (sizeError) {
+        setErrorMessage(sizeError)
+        return
+      }
+
+      setErrorMessage(null)
+      setContentImageUploading(true)
+      try {
+        const { uploadUrl } = await requestPresignedUpload(apiClient, file, THUMBNAIL_S3_KEY)
+        await uploadFileToS3(uploadUrl, file)
+        // 본문에는 서명이 붙지 않은 주소를 남긴다. presigned URL 은 5분이면 만료된다.
+        const markup = `![](${toPublicUrl(uploadUrl)})`
+        setContent((prev) => insertAtCursor(contentRef.current, prev, markup))
+      } catch (err) {
+        setErrorMessage(describeUploadError(err))
+      } finally {
+        setContentImageUploading(false)
+      }
+    },
+    [apiClient]
+  )
 
   useEffect(() => {
     if (!Number.isFinite(id)) {
@@ -313,13 +348,33 @@ export default function EventBoardEditPage() {
           )}
         </div>
 
-        <GdgTextarea
-          label="내용"
-          fullWidth
-          rows={10}
-          value={content}
-          onChange={(event) => setContent(event.target.value)}
-        />
+        <div className="flex flex-col gap-2">
+          <GdgTextarea
+            ref={contentRef}
+            label="내용"
+            fullWidth
+            rows={10}
+            value={content}
+            onChange={(event) => setContent(event.target.value)}
+          />
+          <input
+            ref={contentImageInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleContentImageSelect}
+          />
+          <GdgButton
+            variant="bordered"
+            onClick={() => contentImageInputRef.current?.click()}
+            disabled={contentImageUploading}
+          >
+            {contentImageUploading ? '업로드 중...' : '본문에 이미지 삽입'}
+          </GdgButton>
+          <p className="typo-pc-c1 mobile:typo-m-c1 text-gray-500">
+            커서 자리에 <code>![](주소)</code> 가 들어갑니다. 그 자리에 이미지가 표시됩니다.
+          </p>
+        </div>
 
         <div className="flex flex-col gap-2">
           <span className="typo-pc-s3 mobile:typo-m-s3 uppercase tracking-[0.2em] text-white/80">첨부</span>

--- a/src/app/board/events/edit/page.tsx
+++ b/src/app/board/events/edit/page.tsx
@@ -18,7 +18,12 @@ import { BOARD_MENUS } from '@/components/board/boardMenus'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
 import { fetchEventDetail, updateEvent } from '@/services/board/boardClient'
-import { requestPresignedUpload, uploadFileToS3 } from '@/services/board/uploadClient'
+import {
+  describeUploadError,
+  requestPresignedUpload,
+  uploadFileToS3,
+  validateUploadSize
+} from '@/services/board/uploadClient'
 import type { AttachmentResponse, EventOrganizingTeam } from '@/types/board'
 import { hasAtLeast } from '@/utils/auth/role'
 
@@ -30,7 +35,7 @@ const TEAM_OPTIONS: GdgDropdownOption[] = [
   { id: 'BD', label: 'BD' }
 ]
 
-// TODO: 백엔드 S3KeyType에 boardEvent가 추가되면 그 값과 일치하는지 재확인한다.
+// 백엔드 S3KeyType.boardEvent("board/event") 와 같은 값. develop·main 양쪽에 배포돼 있다.
 const THUMBNAIL_S3_KEY = 'boardEvent'
 
 const createDraftId = (): string =>
@@ -66,7 +71,6 @@ export default function EventBoardEditPage() {
   const [eventEndDate, setEventEndDate] = useState('')
   const [organizingTeam, setOrganizingTeam] = useState<EventOrganizingTeam | ''>('')
   const [content, setContent] = useState('')
-  const [isPublished, setIsPublished] = useState(true)
   const [attachments, setAttachments] = useState<AttachmentDraft[]>([])
   // 새 썸네일을 올리지 않으면 undefined로 보낸다 — 서버는 thumbnailKey가 null이면
   // 기존 값을 유지한다 (EventBoard.update(): "if (thumbnailKey != null) this.thumbnailKey = ...").
@@ -106,7 +110,6 @@ export default function EventBoardEditPage() {
         setEventEndDate(detail.eventEndDate)
         setOrganizingTeam((detail.organizingTeam ?? '') as EventOrganizingTeam | '')
         setContent(detail.content)
-        setIsPublished(detail.isPublished)
         setThumbnailPreview(detail.thumbnailUrl)
         setAttachments(
           detail.attachments.map((attachment) => ({
@@ -137,14 +140,21 @@ export default function EventBoardEditPage() {
       event.target.value = ''
       if (!file) return
 
+      const sizeError = validateUploadSize(file)
+      if (sizeError) {
+        setErrorMessage(sizeError)
+        return
+      }
+
+      setErrorMessage(null)
       setThumbnailPreview(URL.createObjectURL(file))
       setThumbnailUploading(true)
       try {
         const { key, uploadUrl } = await requestPresignedUpload(apiClient, file, THUMBNAIL_S3_KEY)
         await uploadFileToS3(uploadUrl, file)
         setThumbnailKey(key)
-      } catch {
-        setErrorMessage('썸네일 업로드에 실패했습니다.')
+      } catch (err) {
+        setErrorMessage(describeUploadError(err))
       } finally {
         setThumbnailUploading(false)
       }
@@ -170,7 +180,9 @@ export default function EventBoardEditPage() {
         organizingTeam,
         thumbnailKey: thumbnailKey ?? undefined,
         content,
-        isPublished,
+        // 작성 화면과 같은 이유로 공개 선택지를 두지 않는다. true 로 보내므로 예전에 비공개로
+        // 저장돼 목록에서 사라진 글도 한 번 저장하면 다시 드러난다.
+        isPublished: true,
         attachments: attachments
           .filter((item) => item.status === 'done')
           .map((item) =>
@@ -196,7 +208,6 @@ export default function EventBoardEditPage() {
     eventEndDate,
     eventStartDate,
     id,
-    isPublished,
     organizingTeam,
     router,
     thumbnailKey,
@@ -220,7 +231,9 @@ export default function EventBoardEditPage() {
   }
 
   if (loading) {
-    return <p className="py-16 text-center text-white typo-pc-b2 mobile:typo-m-b2">불러오는 중...</p>
+    return (
+      <p className="py-16 text-center text-white typo-pc-b2 mobile:typo-m-b2">불러오는 중...</p>
+    )
   }
 
   if (loadError) {
@@ -307,15 +320,6 @@ export default function EventBoardEditPage() {
           value={content}
           onChange={(event) => setContent(event.target.value)}
         />
-
-        <label className="flex items-center gap-2 typo-pc-b3 mobile:typo-m-b3">
-          <input
-            type="checkbox"
-            checked={isPublished}
-            onChange={(event) => setIsPublished(event.target.checked)}
-          />
-          공개
-        </label>
 
         <div className="flex flex-col gap-2">
           <span className="typo-pc-s3 mobile:typo-m-s3 uppercase tracking-[0.2em] text-white/80">첨부</span>

--- a/src/app/board/events/new/page.tsx
+++ b/src/app/board/events/new/page.tsx
@@ -18,7 +18,12 @@ import { BOARD_MENUS } from '@/components/board/boardMenus'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
 import { createEvent } from '@/services/board/boardClient'
-import { requestPresignedUpload, uploadFileToS3 } from '@/services/board/uploadClient'
+import {
+  describeUploadError,
+  requestPresignedUpload,
+  uploadFileToS3,
+  validateUploadSize
+} from '@/services/board/uploadClient'
 import type { EventOrganizingTeam } from '@/types/board'
 import { hasAtLeast } from '@/utils/auth/role'
 
@@ -30,8 +35,7 @@ const TEAM_OPTIONS: GdgDropdownOption[] = [
   { id: 'BD', label: 'BD' }
 ]
 
-// TODO: 백엔드 S3KeyType에 boardEvent가 추가되면 그 값과 일치하는지 재확인한다.
-// 설계 문서 §7 / 이 계획 상단 "백엔드 계약 출처" 참고 — 아직 develop에 없다.
+// 백엔드 S3KeyType.boardEvent("board/event") 와 같은 값. develop·main 양쪽에 배포돼 있다.
 const THUMBNAIL_S3_KEY = 'boardEvent'
 
 export default function EventBoardNewPage() {
@@ -44,7 +48,6 @@ export default function EventBoardNewPage() {
   const [eventEndDate, setEventEndDate] = useState('')
   const [organizingTeam, setOrganizingTeam] = useState<EventOrganizingTeam | ''>('')
   const [content, setContent] = useState('')
-  const [isPublished, setIsPublished] = useState(true)
   const [attachments, setAttachments] = useState<AttachmentDraft[]>([])
   const [thumbnailKey, setThumbnailKey] = useState<string | null>(null)
   const [thumbnailPreview, setThumbnailPreview] = useState<string | null>(null)
@@ -60,14 +63,21 @@ export default function EventBoardNewPage() {
       event.target.value = ''
       if (!file) return
 
+      const sizeError = validateUploadSize(file)
+      if (sizeError) {
+        setErrorMessage(sizeError)
+        return
+      }
+
+      setErrorMessage(null)
       setThumbnailPreview(URL.createObjectURL(file))
       setThumbnailUploading(true)
       try {
         const { key, uploadUrl } = await requestPresignedUpload(apiClient, file, THUMBNAIL_S3_KEY)
         await uploadFileToS3(uploadUrl, file)
         setThumbnailKey(key)
-      } catch {
-        setErrorMessage('썸네일 업로드에 실패했습니다.')
+      } catch (err) {
+        setErrorMessage(describeUploadError(err))
         setThumbnailPreview(null)
       } finally {
         setThumbnailUploading(false)
@@ -93,7 +103,9 @@ export default function EventBoardNewPage() {
         organizingTeam,
         thumbnailKey: thumbnailKey ?? undefined,
         content,
-        isPublished,
+        // 행사 목록 응답에 isPublished 가 없어 임시저장 뱃지를 띄울 수 없다. 비공개로 저장하면
+        // 작성자도 목록에서 글을 찾지 못하므로 선택지를 없애고 항상 공개로 등록한다.
+        isPublished: true,
         attachments: attachments
           .filter((item) => item.status === 'done')
           .map((item) =>
@@ -118,7 +130,6 @@ export default function EventBoardNewPage() {
     content,
     eventEndDate,
     eventStartDate,
-    isPublished,
     organizingTeam,
     router,
     thumbnailKey,
@@ -209,15 +220,6 @@ export default function EventBoardNewPage() {
           value={content}
           onChange={(event) => setContent(event.target.value)}
         />
-
-        <label className="flex items-center gap-2 typo-pc-b3 mobile:typo-m-b3">
-          <input
-            type="checkbox"
-            checked={isPublished}
-            onChange={(event) => setIsPublished(event.target.checked)}
-          />
-          즉시 공개
-        </label>
 
         <div className="flex flex-col gap-2">
           <span className="typo-pc-s3 mobile:typo-m-s3 uppercase tracking-[0.2em] text-white/80">첨부</span>

--- a/src/app/board/events/new/page.tsx
+++ b/src/app/board/events/new/page.tsx
@@ -3,7 +3,13 @@
 import axios from 'axios'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
-import { useCallback, useRef, useState, type ChangeEvent } from 'react'
+import {
+  useCallback,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type ClipboardEvent
+} from 'react'
 
 import { AttachmentUploader, type AttachmentDraft } from '@/components/board/AttachmentUploader'
 import {
@@ -57,17 +63,21 @@ export default function EventBoardNewPage() {
   const thumbnailInputRef = useRef<HTMLInputElement | null>(null)
 
   const [contentImageUploading, setContentImageUploading] = useState(false)
-  const contentImageInputRef = useRef<HTMLInputElement | null>(null)
-  const contentRef = useRef<HTMLTextAreaElement | null>(null)
 
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  const handleContentImageSelect = useCallback(
-    async (event: ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0]
-      event.target.value = ''
+  const handleContentPaste = useCallback(
+    async (event: ClipboardEvent<HTMLTextAreaElement>) => {
+      const file = Array.from(event.clipboardData.files).find((item) =>
+        item.type.startsWith('image/')
+      )
+      // 이미지가 아니면 손대지 않는다 — 평범한 텍스트 붙여넣기가 그대로 동작해야 한다.
       if (!file) return
+
+      // 붙여넣은 시점의 자리를 잡아 둔다. 업로드를 기다리는 사이 커서가 움직일 수 있다.
+      const { selectionStart, selectionEnd } = event.currentTarget
+      event.preventDefault()
 
       const sizeError = validateUploadSize(file)
       if (sizeError) {
@@ -82,7 +92,7 @@ export default function EventBoardNewPage() {
         await uploadFileToS3(uploadUrl, file)
         // 본문에는 서명이 붙지 않은 주소를 남긴다. presigned URL 은 5분이면 만료된다.
         const markup = `![](${toPublicUrl(uploadUrl)})`
-        setContent((prev) => insertAtCursor(contentRef.current, prev, markup))
+        setContent((prev) => insertAtCursor(prev, selectionStart, selectionEnd, markup))
       } catch (err) {
         setErrorMessage(describeUploadError(err))
       } finally {
@@ -250,29 +260,17 @@ export default function EventBoardNewPage() {
 
         <div className="flex flex-col gap-2">
           <GdgTextarea
-            ref={contentRef}
             label="내용"
             fullWidth
             rows={10}
             value={content}
             onChange={(event) => setContent(event.target.value)}
+            onPaste={handleContentPaste}
           />
-          <input
-            ref={contentImageInputRef}
-            type="file"
-            accept="image/*"
-            className="hidden"
-            onChange={handleContentImageSelect}
-          />
-          <GdgButton
-            variant="bordered"
-            onClick={() => contentImageInputRef.current?.click()}
-            disabled={contentImageUploading}
-          >
-            {contentImageUploading ? '업로드 중...' : '본문에 이미지 삽입'}
-          </GdgButton>
           <p className="typo-pc-c1 mobile:typo-m-c1 text-gray-500">
-            커서 자리에 <code>![](주소)</code> 가 들어갑니다. 그 자리에 이미지가 표시됩니다.
+            {contentImageUploading
+              ? '이미지 올리는 중...'
+              : '이미지를 복사해 붙여넣으면 그 자리에 들어갑니다.'}
           </p>
         </div>
 

--- a/src/app/board/events/new/page.tsx
+++ b/src/app/board/events/new/page.tsx
@@ -21,11 +21,13 @@ import { createEvent } from '@/services/board/boardClient'
 import {
   describeUploadError,
   requestPresignedUpload,
+  toPublicUrl,
   uploadFileToS3,
   validateUploadSize
 } from '@/services/board/uploadClient'
 import type { EventOrganizingTeam } from '@/types/board'
 import { hasAtLeast } from '@/utils/auth/role'
+import { insertAtCursor } from '@/utils/insertAtCursor'
 
 const TEAM_OPTIONS: GdgDropdownOption[] = [
   { id: 'HQ', label: 'HQ' },
@@ -54,8 +56,41 @@ export default function EventBoardNewPage() {
   const [thumbnailUploading, setThumbnailUploading] = useState(false)
   const thumbnailInputRef = useRef<HTMLInputElement | null>(null)
 
+  const [contentImageUploading, setContentImageUploading] = useState(false)
+  const contentImageInputRef = useRef<HTMLInputElement | null>(null)
+  const contentRef = useRef<HTMLTextAreaElement | null>(null)
+
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const handleContentImageSelect = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0]
+      event.target.value = ''
+      if (!file) return
+
+      const sizeError = validateUploadSize(file)
+      if (sizeError) {
+        setErrorMessage(sizeError)
+        return
+      }
+
+      setErrorMessage(null)
+      setContentImageUploading(true)
+      try {
+        const { uploadUrl } = await requestPresignedUpload(apiClient, file, THUMBNAIL_S3_KEY)
+        await uploadFileToS3(uploadUrl, file)
+        // 본문에는 서명이 붙지 않은 주소를 남긴다. presigned URL 은 5분이면 만료된다.
+        const markup = `![](${toPublicUrl(uploadUrl)})`
+        setContent((prev) => insertAtCursor(contentRef.current, prev, markup))
+      } catch (err) {
+        setErrorMessage(describeUploadError(err))
+      } finally {
+        setContentImageUploading(false)
+      }
+    },
+    [apiClient]
+  )
 
   const handleThumbnailSelect = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
@@ -213,13 +248,33 @@ export default function EventBoardNewPage() {
           )}
         </div>
 
-        <GdgTextarea
-          label="내용"
-          fullWidth
-          rows={10}
-          value={content}
-          onChange={(event) => setContent(event.target.value)}
-        />
+        <div className="flex flex-col gap-2">
+          <GdgTextarea
+            ref={contentRef}
+            label="내용"
+            fullWidth
+            rows={10}
+            value={content}
+            onChange={(event) => setContent(event.target.value)}
+          />
+          <input
+            ref={contentImageInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleContentImageSelect}
+          />
+          <GdgButton
+            variant="bordered"
+            onClick={() => contentImageInputRef.current?.click()}
+            disabled={contentImageUploading}
+          >
+            {contentImageUploading ? '업로드 중...' : '본문에 이미지 삽입'}
+          </GdgButton>
+          <p className="typo-pc-c1 mobile:typo-m-c1 text-gray-500">
+            커서 자리에 <code>![](주소)</code> 가 들어갑니다. 그 자리에 이미지가 표시됩니다.
+          </p>
+        </div>
 
         <div className="flex flex-col gap-2">
           <span className="typo-pc-s3 mobile:typo-m-s3 uppercase tracking-[0.2em] text-white/80">첨부</span>

--- a/src/app/board/events/page.tsx
+++ b/src/app/board/events/page.tsx
@@ -69,16 +69,33 @@ export default function EventBoardListPage() {
     setSubmittedKeyword(keyword)
   }, [keyword])
 
+  // 제목만 너비를 비워 남은 폭을 전부 가져가게 한다 (BoardList 는 table-fixed).
   const columns: BoardListColumn<EventBoardSummary>[] = [
-    { key: 'title', header: '제목', render: (item) => item.title, primary: true },
+    {
+      key: 'title',
+      header: '제목',
+      render: (item) => <span className="block truncate">{item.title}</span>,
+      primary: true
+    },
     {
       key: 'period',
       header: '기간',
-      render: (item) => `${formatDate(item.eventStartDate)} ~ ${formatDate(item.eventEndDate)}`
+      render: (item) => `${formatDate(item.eventStartDate)} ~ ${formatDate(item.eventEndDate)}`,
+      className: 'w-52'
     },
-    { key: 'team', header: '팀', render: (item) => item.organizingTeam ?? '-' },
-    { key: 'author', header: '작성자', render: (item) => item.authorName },
-    { key: 'status', header: '상태', render: (item) => STATUS_LABEL[item.status] ?? item.status }
+    {
+      key: 'team',
+      header: '팀',
+      render: (item) => item.organizingTeam ?? '-',
+      className: 'w-28'
+    },
+    { key: 'author', header: '작성자', render: (item) => item.authorName, className: 'w-28' },
+    {
+      key: 'status',
+      header: '상태',
+      render: (item) => STATUS_LABEL[item.status] ?? item.status,
+      className: 'w-20'
+    }
   ]
 
   const canWrite = hasAtLeast(user?.userRole, 'CORE')

--- a/src/app/board/events/page.tsx
+++ b/src/app/board/events/page.tsx
@@ -136,6 +136,20 @@ export default function EventBoardListPage() {
             columns={columns}
             getRowKey={(item) => item.id}
             onRowClick={(item) => router.push(`/board/events/detail?id=${item.id}`)}
+            thumbnail={(item) => (
+              <div className="h-12 w-20 overflow-hidden rounded bg-gray-100">
+                {item.thumbnailUrl && (
+                  // next/image 는 못 쓴다 — S3 호스트를 remotePatterns 에 적을 수 없다.
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={item.thumbnailUrl}
+                    alt=""
+                    loading="lazy"
+                    className="h-full w-full object-cover"
+                  />
+                )}
+              </div>
+            )}
           />
         )}
 

--- a/src/app/recruit/member/completed/page.tsx
+++ b/src/app/recruit/member/completed/page.tsx
@@ -170,12 +170,12 @@ export default function RecruitSubmit() {
                 <span className="font-bold mr-2">카카오톡 오픈채팅</span>
                 <br />
                 <Link
-                  href="https://open.kakao.com/o/s3fxV67h"
+                  href="https://open.kakao.com/o/s2OqrcIi"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="typo-pc-b3 mobile:typo-m-c1 text-[#9EC0FF] underline break-all"
                 >
-                  https://open.kakao.com/o/s3fxV67h
+                  https://open.kakao.com/o/s2OqrcIi
                 </Link>
               </Bullet>
               <Bullet>

--- a/src/components/board/AttachmentList.tsx
+++ b/src/components/board/AttachmentList.tsx
@@ -15,34 +15,15 @@ const formatFileSize = (bytes: number): string => {
 const isFileAttachment = (attachment: AttachmentResponse): boolean =>
   attachment.kind ? attachment.kind === 'FILE' : Boolean(attachment.fileUrl ?? attachment.fileName)
 
-const IMAGE_EXTENSION = /\.(png|jpe?g|gif|webp|svg|avif)$/i
-
-/**
- * 확장자로만 이미지를 가린다.
- *
- * URL 이면 경로만 본다 — presigned URL 은 ?X-Amz-... 가 붙어 확장자가 끝에 오지 않는다.
- * URL 이 아니면(파일명) 그대로 본다.
- *
- * 확장자 없는 CDN 링크는 이미지여도 링크로 남는다. 일단 <img> 로 그려보고 실패하면
- * 되돌리는 방법이 더 많이 잡지만, 일반 웹페이지 링크가 한 프레임 깨진 이미지로
- * 보였다가 바뀐다. 놓치는 쪽을 택했다.
- */
-const hasImageExtension = (value: string | null | undefined): boolean => {
-  if (!value) return false
-
-  let path = value
-  try {
-    path = new URL(value).pathname
-  } catch {
-    // URL 이 아니다. 파일명으로 보고 그대로 검사한다.
-  }
-  return IMAGE_EXTENSION.test(path)
-}
-
 export interface AttachmentListProps {
   attachments: AttachmentResponse[]
 }
 
+/**
+ * 첨부는 이미지여도 미리보기로 펼치지 않는다. 본문에 넣을 이미지는 본문의 이미지 문법으로
+ * 넣고, 여기는 내려받을 것들의 목록으로만 둔다 — 전에는 이미지 첨부가 본문 아래에 크게
+ * 펼쳐져 본문의 일부처럼 보였다.
+ */
 export function AttachmentList({ attachments }: AttachmentListProps) {
   if (attachments.length === 0) return null
 
@@ -51,27 +32,6 @@ export function AttachmentList({ attachments }: AttachmentListProps) {
       {attachments.map((attachment) => {
         const isFile = isFileAttachment(attachment)
         const href = (isFile ? attachment.fileUrl : attachment.url) ?? null
-        // 파일은 원본 파일명이 확장자를 갖고 있다. 링크는 주소 자체를 본다.
-        const imageSource =
-          href && hasImageExtension(isFile ? (attachment.fileName ?? href) : href) ? href : null
-
-        if (imageSource) {
-          return (
-            <li key={attachment.id}>
-              {/* 원본을 새 탭에서 열 수 있게 감싼다. 미리보기는 max-h 로 잘라 본문을 밀지 않는다. */}
-              <a href={imageSource} target="_blank" rel="noreferrer" className="block">
-                {/* next/image 는 못 쓴다 — 임의의 외부 호스트라 remotePatterns 에 적을 수 없다. */}
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={imageSource}
-                  alt={attachment.fileName ?? '첨부 이미지'}
-                  loading="lazy"
-                  className="max-h-96 w-auto max-w-full rounded-lg"
-                />
-              </a>
-            </li>
-          )
-        }
 
         if (isFile) {
           return (

--- a/src/components/board/AttachmentUploader.tsx
+++ b/src/components/board/AttachmentUploader.tsx
@@ -5,7 +5,12 @@ import { Reorder } from 'framer-motion'
 import { useCallback, useRef, useState, type ChangeEvent } from 'react'
 
 import { GdgFileCard, GdgInputField, GdgUploadButton } from '@/components/ui/design-system'
-import { requestPresignedUpload, uploadFileToS3 } from '@/services/board/uploadClient'
+import {
+  describeUploadError,
+  requestPresignedUpload,
+  uploadFileToS3,
+  validateUploadSize
+} from '@/services/board/uploadClient'
 import type { AttachmentKind } from '@/types/board'
 
 export type AttachmentDraftStatus = 'uploading' | 'done' | 'error'
@@ -63,11 +68,8 @@ export function AttachmentUploader({
         const { key, uploadUrl } = await requestPresignedUpload(apiClient, file, s3key)
         await uploadFileToS3(uploadUrl, file)
         updateDraft(id, { status: 'done', fileKey: key, fileName: file.name })
-      } catch {
-        updateDraft(id, {
-          status: 'error',
-          errorMessage: '업로드에 실패했습니다. 다시 시도해 주세요.'
-        })
+      } catch (err) {
+        updateDraft(id, { status: 'error', errorMessage: describeUploadError(err) })
       }
     },
     [apiClient, s3key, updateDraft]
@@ -80,6 +82,17 @@ export function AttachmentUploader({
       if (!file || isFull) return
 
       const id = createDraftId()
+
+      // 크기 초과는 재시도해도 결과가 같으므로 file 을 들려 보내지 않는다 — 재시도 버튼이 뜨지 않는다.
+      const sizeError = validateUploadSize(file)
+      if (sizeError) {
+        onChange([
+          ...attachments,
+          { id, kind: 'FILE', fileName: file.name, status: 'error', errorMessage: sizeError }
+        ])
+        return
+      }
+
       onChange([
         ...attachments,
         { id, kind: 'FILE', fileName: file.name, status: 'uploading', file }

--- a/src/components/board/AttachmentUploader.tsx
+++ b/src/components/board/AttachmentUploader.tsx
@@ -2,7 +2,14 @@
 
 import type { AxiosInstance } from 'axios'
 import { Reorder } from 'framer-motion'
-import { useCallback, useRef, useState, type ChangeEvent } from 'react'
+import {
+  useCallback,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type Dispatch,
+  type SetStateAction
+} from 'react'
 
 import { GdgFileCard, GdgInputField, GdgUploadButton } from '@/components/ui/design-system'
 import {
@@ -30,7 +37,11 @@ export interface AttachmentDraft {
 
 export interface AttachmentUploaderProps {
   attachments: AttachmentDraft[]
-  onChange: (attachments: AttachmentDraft[]) => void
+  /**
+   * 업로드는 비동기라 완료 시점의 목록이 시작 시점과 다를 수 있다. 갱신을 항상 함수형으로
+   * 넘길 수 있어야 진행 중인 업로드가 그 사이 추가된 항목을 지우지 않는다.
+   */
+  onChange: Dispatch<SetStateAction<AttachmentDraft[]>>
   apiClient: AxiosInstance
   s3key: string
   maxCount?: number
@@ -55,11 +66,13 @@ export function AttachmentUploader({
   const isFull = attachments.length >= maxCount
   const hasPendingLink = linkInput.trim().length > 0
 
+  // 렌더 시점의 attachments 를 닫아 두면 업로드가 끝나는 순간 그 사이에 추가된 항목이
+  // 통째로 지워진다. 함수형으로 최신 목록을 받아 갱신한다.
   const updateDraft = useCallback(
     (id: string, patch: Partial<AttachmentDraft>) => {
-      onChange(attachments.map((item) => (item.id === id ? { ...item, ...patch } : item)))
+      onChange((prev) => prev.map((item) => (item.id === id ? { ...item, ...patch } : item)))
     },
-    [attachments, onChange]
+    [onChange]
   )
 
   const uploadFile = useCallback(
@@ -86,20 +99,20 @@ export function AttachmentUploader({
       // 크기 초과는 재시도해도 결과가 같으므로 file 을 들려 보내지 않는다 — 재시도 버튼이 뜨지 않는다.
       const sizeError = validateUploadSize(file)
       if (sizeError) {
-        onChange([
-          ...attachments,
+        onChange((prev) => [
+          ...prev,
           { id, kind: 'FILE', fileName: file.name, status: 'error', errorMessage: sizeError }
         ])
         return
       }
 
-      onChange([
-        ...attachments,
+      onChange((prev) => [
+        ...prev,
         { id, kind: 'FILE', fileName: file.name, status: 'uploading', file }
       ])
       void uploadFile(file, id)
     },
-    [attachments, isFull, onChange, uploadFile]
+    [isFull, onChange, uploadFile]
   )
 
   const handleRetry = useCallback(

--- a/src/components/board/BoardContent.tsx
+++ b/src/components/board/BoardContent.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react'
+
+/**
+ * 본문에 넣은 이미지 문법. 마크다운의 이미지 표기 하나만 받는다.
+ * 굵게·제목 같은 다른 문법은 지원하지 않는다 — 기존 글이 마크다운으로 재해석되면
+ * 의도치 않게 보이므로, 새로 넣기로 한 이 표기만 특별 취급한다.
+ */
+const IMAGE_PATTERN = /!\[([^\]]*)\]\(([^)\s]+)\)/g
+
+/**
+ * http(s) 만 그린다. javascript: 나 data: 로 시작하는 주소를 그대로 <img src> 에 넣으면
+ * 작성 권한이 있는 사람이 다른 사람 화면에서 스크립트를 돌릴 수 있다.
+ */
+const isSafeImageUrl = (url: string): boolean => /^https?:\/\//i.test(url)
+
+type Segment = { kind: 'text'; value: string } | { kind: 'image'; alt: string; url: string }
+
+/** 본문을 텍스트와 이미지 조각으로 가른다. 안전하지 않은 주소는 원문 그대로 텍스트로 남긴다. */
+const toSegments = (content: string): Segment[] => {
+  const segments: Segment[] = []
+  let cursor = 0
+
+  for (const match of content.matchAll(IMAGE_PATTERN)) {
+    const [raw, alt, url] = match
+    const start = match.index ?? 0
+
+    if (start > cursor) {
+      segments.push({ kind: 'text', value: content.slice(cursor, start) })
+    }
+    segments.push(isSafeImageUrl(url) ? { kind: 'image', alt, url } : { kind: 'text', value: raw })
+    cursor = start + raw.length
+  }
+
+  if (cursor < content.length) {
+    segments.push({ kind: 'text', value: content.slice(cursor) })
+  }
+  return segments
+}
+
+export interface BoardContentProps {
+  content: string
+}
+
+export function BoardContent({ content }: BoardContentProps): ReactNode {
+  const segments = toSegments(content)
+
+  return (
+    <div className="flex flex-col gap-2 typo-pc-b2 mobile:typo-m-b2">
+      {segments.map((segment, index) =>
+        segment.kind === 'image' ? (
+          <a
+            key={index}
+            href={segment.url}
+            target="_blank"
+            rel="noreferrer"
+            className="block w-fit"
+          >
+            {/* next/image 는 못 쓴다 — 임의의 외부 호스트라 remotePatterns 에 적을 수 없다. */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={segment.url}
+              alt={segment.alt}
+              loading="lazy"
+              className="max-h-[520px] w-auto max-w-full rounded-lg"
+            />
+          </a>
+        ) : (
+          <p key={index} className="whitespace-pre-wrap">
+            {segment.value}
+          </p>
+        )
+      )}
+    </div>
+  )
+}

--- a/src/components/board/BoardList.tsx
+++ b/src/components/board/BoardList.tsx
@@ -21,6 +21,12 @@ export interface BoardListProps<T> {
   getRowKey: (item: T) => string | number
   onRowClick?: (item: T) => void
   emptyMessage?: string
+  /**
+   * 행 맨 앞에 붙일 그림. 열로 넣으면 모바일 카드에서 "썸네일" 이라는 라벨과 함께
+   * 값처럼 나열되므로 자리를 따로 준다. 넘기지 않으면 그림 칸 자체가 없다 —
+   * 공지·자유게시판은 이 prop 을 쓰지 않는다.
+   */
+  thumbnail?: (item: T) => ReactNode
 }
 
 export function BoardList<T>({
@@ -28,7 +34,8 @@ export function BoardList<T>({
   columns,
   getRowKey,
   onRowClick,
-  emptyMessage = '등록된 글이 없습니다.'
+  emptyMessage = '등록된 글이 없습니다.',
+  thumbnail
 }: BoardListProps<T>) {
   if (items.length === 0) {
     return (
@@ -46,6 +53,7 @@ export function BoardList<T>({
         <table className="w-full min-w-[640px] border-collapse text-left text-white">
           <thead>
             <tr className="border-b border-gray-800 typo-pc-s3 mobile:typo-m-s3">
+              {thumbnail && <th className="w-24 px-4 py-3" />}
               {columns.map((column) => (
                 <th key={column.key} className={cn('px-4 py-3', column.className)}>
                   {column.header}
@@ -63,6 +71,7 @@ export function BoardList<T>({
                   onRowClick && 'cursor-pointer hover:bg-gray-100'
                 )}
               >
+                {thumbnail && <td className="w-24 px-4 py-3">{thumbnail(item)}</td>}
                 {columns.map((column) => (
                   <td key={column.key} className={cn('px-4 py-3', column.className)}>
                     {column.render(item)}
@@ -84,19 +93,22 @@ export function BoardList<T>({
             <div
               onClick={() => onRowClick?.(item)}
               className={cn(
-                'w-full rounded-xl border border-gray-200 px-4 py-3',
+                'flex w-full gap-3 rounded-xl border border-gray-200 px-4 py-3',
                 onRowClick && 'cursor-pointer active:bg-gray-100'
               )}
             >
-              <p className="text-white typo-m-s3">{primaryColumn.render(item)}</p>
-              <dl className="mt-2 flex flex-col gap-1 typo-m-c1">
-                {metaColumns.map((column) => (
-                  <div key={column.key} className="flex items-start gap-2">
-                    <dt className="w-14 shrink-0 text-gray-600">{column.header}</dt>
-                    <dd className="min-w-0 flex-1 text-gray-800">{column.render(item)}</dd>
-                  </div>
-                ))}
-              </dl>
+              {thumbnail && <div className="shrink-0">{thumbnail(item)}</div>}
+              <div className="min-w-0 flex-1">
+                <p className="text-white typo-m-s3">{primaryColumn.render(item)}</p>
+                <dl className="mt-2 flex flex-col gap-1 typo-m-c1">
+                  {metaColumns.map((column) => (
+                    <div key={column.key} className="flex items-start gap-2">
+                      <dt className="w-14 shrink-0 text-gray-600">{column.header}</dt>
+                      <dd className="min-w-0 flex-1 text-gray-800">{column.render(item)}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
             </div>
           </li>
         ))}

--- a/src/components/board/BoardList.tsx
+++ b/src/components/board/BoardList.tsx
@@ -50,7 +50,10 @@ export function BoardList<T>({
     <>
       {/* PC: 표 */}
       <div className="hidden w-full overflow-x-auto pc:block">
-        <table className="w-full min-w-[640px] border-collapse text-left text-white">
+        {/* table-fixed 여야 열 너비가 내용에 밀리지 않는다. auto 로 두면 제목이 긴 글 하나
+            때문에 기간·작성자 열까지 통째로 움직여 행마다 칸이 어긋나 보인다.
+            너비를 주지 않은 열(제목)이 남은 폭을 가져간다. */}
+        <table className="w-full min-w-[640px] table-fixed border-collapse text-left text-white">
           <thead>
             <tr className="border-b border-gray-800 typo-pc-s3 mobile:typo-m-s3">
               {thumbnail && <th className="w-24 px-4 py-3" />}

--- a/src/components/landing/OnboardingLanding.tsx
+++ b/src/components/landing/OnboardingLanding.tsx
@@ -253,14 +253,14 @@ const faqs: Array<{ question: string; answer: string[]; accent: Accent }> = [
   {
     question: '문의는 어디로 하면 되나요?',
     answer: [
-      '문의는 공식메일(gdsc.inha@gmail.com) 또는 카카오톡(링크: https://open.kakao.com/o/s3fxV67h)으로 해주시면 답변드리겠습니다.'
+      '문의는 공식메일(gdsc.inha@gmail.com) 또는 카카오톡(링크: https://open.kakao.com/o/s2OqrcIi)으로 해주시면 답변드리겠습니다.'
     ],
     accent: 'blue'
   }
 ]
 
 const pageSectionClass = 'h-svh min-h-[640px] shrink-0'
-const kakaoOpenChatUrl = 'https://open.kakao.com/o/s3fxV67h'
+const kakaoOpenChatUrl = 'https://open.kakao.com/o/s2OqrcIi'
 
 const pageIds = [
   'intro',

--- a/src/services/board/uploadClient.ts
+++ b/src/services/board/uploadClient.ts
@@ -1,6 +1,28 @@
-import type { AxiosInstance } from 'axios'
+import axios, { type AxiosInstance } from 'axios'
 
 const unwrapOnce = <T>(payload: unknown): T => (payload as { data: T }).data
+
+/** 서버 ResourceService.MAX_FILE_SIZE 와 같은 값. 넘으면 presigned 요청이 413 이다. */
+export const MAX_UPLOAD_SIZE = 10 * 1024 * 1024
+
+/** 업로드 가능한 크기면 null, 아니면 사용자에게 보여줄 사유. 서버 왕복 전에 거른다. */
+export const validateUploadSize = (file: File): string | null =>
+  file.size > MAX_UPLOAD_SIZE
+    ? `파일 크기는 10MB를 넘을 수 없습니다. (선택한 파일: ${(file.size / 1024 / 1024).toFixed(1)}MB)`
+    : null
+
+/**
+ * 업로드 실패 사유를 화면에 띄울 문구로 바꾼다. 서버는 413에 "파일 크기는 10Mb를 넘을 수
+ * 없습니다" 처럼 원인을 담아 주는데, 호출부가 이를 버리고 "업로드에 실패했습니다" 만 띄우면
+ * 사용자는 무엇을 고쳐야 할지 알 수 없다.
+ */
+export const describeUploadError = (err: unknown): string => {
+  if (axios.isAxiosError(err) && typeof err.response?.data?.message === 'string') {
+    return err.response.data.message
+  }
+  if (err instanceof Error && err.message) return err.message
+  return '업로드에 실패했습니다.'
+}
 
 export interface PresignedUpload {
   key: string

--- a/src/services/board/uploadClient.ts
+++ b/src/services/board/uploadClient.ts
@@ -44,6 +44,15 @@ export const requestPresignedUpload = async (
 }
 
 /**
+ * 업로드한 객체를 읽을 때 쓸 주소. presigned URL 은 5분이면 만료되는 서명 쿼리를 달고
+ * 있으므로, 본문에 박아 두려면 쿼리를 떼야 한다. 버킷 객체는 무인증 GET 이 된다.
+ */
+export const toPublicUrl = (uploadUrl: string): string => {
+  const url = new URL(uploadUrl)
+  return url.origin + url.pathname
+}
+
+/**
  * presigned URL은 서명에 헤더 집합이 포함돼 있어 Authorization 헤더 등을 더 붙이면
  * 서명이 깨진다. apiClient가 아니라 순수 fetch를 쓴다.
  */

--- a/src/utils/insertAtCursor.ts
+++ b/src/utils/insertAtCursor.ts
@@ -1,0 +1,17 @@
+/**
+ * textarea 의 커서 자리에 텍스트를 끼워 넣은 결과를 돌려준다. 선택 영역이 있으면 그것을 덮는다.
+ * ref 가 아직 없으면(포커스한 적이 없는 경우) 끝에 줄을 바꿔 붙인다.
+ *
+ * <textarea> 를 직접 고치지 않고 새 문자열만 만든다 — 값은 React state 가 갖고 있다.
+ */
+export const insertAtCursor = (
+  textarea: HTMLTextAreaElement | null,
+  value: string,
+  insertion: string
+): string => {
+  if (!textarea) return value ? `${value}\n${insertion}` : insertion
+
+  const start = textarea.selectionStart ?? value.length
+  const end = textarea.selectionEnd ?? value.length
+  return value.slice(0, start) + insertion + value.slice(end)
+}

--- a/src/utils/insertAtCursor.ts
+++ b/src/utils/insertAtCursor.ts
@@ -1,17 +1,13 @@
 /**
- * textarea 의 커서 자리에 텍스트를 끼워 넣은 결과를 돌려준다. 선택 영역이 있으면 그것을 덮는다.
- * ref 가 아직 없으면(포커스한 적이 없는 경우) 끝에 줄을 바꿔 붙인다.
+ * 커서 자리(선택 영역이 있으면 그 범위)를 insertion 으로 갈아 끼운 문자열을 돌려준다.
  *
  * <textarea> 를 직접 고치지 않고 새 문자열만 만든다 — 값은 React state 가 갖고 있다.
+ * 위치를 인자로 받는 이유는 붙여넣기 직후 업로드가 끝날 때까지 시간이 걸려서다.
+ * 그 사이 커서가 움직일 수 있으므로, 붙여넣은 시점의 자리를 잡아 두고 거기에 넣는다.
  */
 export const insertAtCursor = (
-  textarea: HTMLTextAreaElement | null,
   value: string,
+  start: number,
+  end: number,
   insertion: string
-): string => {
-  if (!textarea) return value ? `${value}\n${insertion}` : insertion
-
-  const start = textarea.selectionStart ?? value.length
-  const end = textarea.selectionEnd ?? value.length
-  return value.slice(0, start) + insertion + value.slice(end)
-}
+): string => value.slice(0, start) + insertion + value.slice(end)


### PR DESCRIPTION
## 요약

행사게시판 파일 업로드가 동작하지 않던 문제를 고치고, 썸네일·첨부·본문의 자리를 나눈다. 카카오톡 오픈채팅 링크도 교체한다.

## 변경

**첨부가 아예 안 되던 버그** — 파일을 첨부하면 목록에 "업로드 중"으로 잠깐 뜨다가 업로드가 끝나는 순간 사라졌다(dev 재현: 56ms 에 나타나 161ms 에 소멸). `updateDraft` 가 렌더 시점의 `attachments` 를 클로저에 닫아 두어, 업로드 완료 후 항목을 더하기 *이전* 배열로 덮어쓰는 것이 원인이다. `onChange` 를 `Dispatch<SetStateAction<...>>` 로 바꿔 갱신을 함수형으로 넘긴다. **운영도 동일하게 깨져 있다.**

**업로드 실패 사유가 안 보이던 문제** — `catch` 가 에러 객체를 받지 않아 서버 메시지를 버리고 "업로드에 실패했습니다" 한 문장만 띄웠다. 운영에서 재현해 보니 presigned 발급·S3 PUT·버킷 CORS 는 모두 정상이고 실제로 걸리는 조건은 10MB 초과(413)뿐이었는데, 서버가 주는 "파일 크기는 10Mb를 넘을 수 없습니다" 가 화면에 닿지 않았다. 서버 메시지를 살려 표시하고, 파일 선택 즉시 크기를 검사해 서버 왕복 전에 안내한다.

**썸네일·첨부·본문의 자리 분리**
- 썸네일을 목록에 띄운다. 서버는 `thumbnailUrl` 을 내려주고 있었는데 화면이 쓰지 않아 글을 열기 전에는 볼 수 없었다.
- 상세에서는 썸네일을 뺀다. 본문에 같은 이미지를 넣으면 두 번 보인다.
- 첨부는 이미지여도 펼치지 않는다. 전에는 본문 아래에 크게 깔려 본문의 일부처럼 보였다.
- 본문에 이미지를 넣을 수 있다. 내용 칸에 이미지를 붙여넣으면 그 자리에 들어간다.

**목록 열 너비 고정** — 표가 `table-auto` 라 제목이 긴 글 하나 때문에 기간·팀·작성자 열까지 밀렸다. `table-fixed` 로 바꾸고 제목만 너비를 비워 남은 폭을 갖게 한다.

**'즉시 공개' 체크박스 제거** — 행사 목록 응답에 `isPublished` 가 없어 임시저장 뱃지를 띄울 수 없고, 비공개로 저장하면 작성자조차 목록에서 글을 찾지 못했다.

**카카오톡 오픈채팅 링크 교체** — 일반 모집 지원완료 페이지와 온보딩 FAQ. 코어 모집 경로에는 링크가 없다.

## 검증

dev 에서 실제로 확인했다.

- 첨부 2개 연속 추가 → 둘 다 남아 있음, 그 뒤 10MB 초과 파일 추가 → 기존 2개 유지 + 크기 안내
- 썸네일 업로드 성공, 목록에 표시됨 / 상세에서는 사라짐
- 첨부 `.png` 가 파일 카드로만 표시됨
- 제목을 12배 길게 만들어도 열 너비 불변, 말줄임 동작
- `yarn build` · `yarn lint` 통과

## 배포 후 확인

`master` 머지는 곧 운영 배포다. S3 sync 후 CloudFront 전파에 시간이 걸리므로, 반영은 `/board/events/` 의 JS 청크가 바뀌는지로 확인한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KqZ35KmwzfReH9eCNnSEE