### PR TITLE
공지·자유게시판 본문 이미지 붙여넣기와 목록 양식 통일

### DIFF
--- a/src/app/board/events/edit/page.tsx
+++ b/src/app/board/events/edit/page.tsx
@@ -3,14 +3,7 @@
 import axios from 'axios'
 import Image from 'next/image'
 import { useRouter, useSearchParams } from 'next/navigation'
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type ChangeEvent,
-  type ClipboardEvent
-} from 'react'
+import { useCallback, useEffect, useRef, useState, type ChangeEvent } from 'react'
 
 import { AttachmentUploader, type AttachmentDraft } from '@/components/board/AttachmentUploader'
 import {
@@ -28,13 +21,12 @@ import { fetchEventDetail, updateEvent } from '@/services/board/boardClient'
 import {
   describeUploadError,
   requestPresignedUpload,
-  toPublicUrl,
   uploadFileToS3,
   validateUploadSize
 } from '@/services/board/uploadClient'
+import { useContentImagePaste } from '@/hooks/useContentImagePaste'
 import type { AttachmentResponse, EventOrganizingTeam } from '@/types/board'
 import { hasAtLeast } from '@/utils/auth/role'
-import { insertAtCursor } from '@/utils/insertAtCursor'
 
 const TEAM_OPTIONS: GdgDropdownOption[] = [
   { id: 'HQ', label: 'HQ' },
@@ -89,45 +81,16 @@ export default function EventBoardEditPage() {
   const [thumbnailUploading, setThumbnailUploading] = useState(false)
   const thumbnailInputRef = useRef<HTMLInputElement | null>(null)
 
-  const [contentImageUploading, setContentImageUploading] = useState(false)
-
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  const handleContentPaste = useCallback(
-    async (event: ClipboardEvent<HTMLTextAreaElement>) => {
-      const file = Array.from(event.clipboardData.files).find((item) =>
-        item.type.startsWith('image/')
-      )
-      // 이미지가 아니면 손대지 않는다 — 평범한 텍스트 붙여넣기가 그대로 동작해야 한다.
-      if (!file) return
-
-      // 붙여넣은 시점의 자리를 잡아 둔다. 업로드를 기다리는 사이 커서가 움직일 수 있다.
-      const { selectionStart, selectionEnd } = event.currentTarget
-      event.preventDefault()
-
-      const sizeError = validateUploadSize(file)
-      if (sizeError) {
-        setErrorMessage(sizeError)
-        return
-      }
-
-      setErrorMessage(null)
-      setContentImageUploading(true)
-      try {
-        const { uploadUrl } = await requestPresignedUpload(apiClient, file, THUMBNAIL_S3_KEY)
-        await uploadFileToS3(uploadUrl, file)
-        // 본문에는 서명이 붙지 않은 주소를 남긴다. presigned URL 은 5분이면 만료된다.
-        const markup = `![](${toPublicUrl(uploadUrl)})`
-        setContent((prev) => insertAtCursor(prev, selectionStart, selectionEnd, markup))
-      } catch (err) {
-        setErrorMessage(describeUploadError(err))
-      } finally {
-        setContentImageUploading(false)
-      }
-    },
-    [apiClient]
-  )
+  const { uploading: contentImageUploading, handlePaste: handleContentPaste } =
+    useContentImagePaste({
+      apiClient,
+      s3key: THUMBNAIL_S3_KEY,
+      setContent,
+      setErrorMessage
+    })
 
   useEffect(() => {
     if (!Number.isFinite(id)) {

--- a/src/app/board/events/new/page.tsx
+++ b/src/app/board/events/new/page.tsx
@@ -3,13 +3,7 @@
 import axios from 'axios'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
-import {
-  useCallback,
-  useRef,
-  useState,
-  type ChangeEvent,
-  type ClipboardEvent
-} from 'react'
+import { useCallback, useRef, useState, type ChangeEvent } from 'react'
 
 import { AttachmentUploader, type AttachmentDraft } from '@/components/board/AttachmentUploader'
 import {
@@ -27,13 +21,12 @@ import { createEvent } from '@/services/board/boardClient'
 import {
   describeUploadError,
   requestPresignedUpload,
-  toPublicUrl,
   uploadFileToS3,
   validateUploadSize
 } from '@/services/board/uploadClient'
+import { useContentImagePaste } from '@/hooks/useContentImagePaste'
 import type { EventOrganizingTeam } from '@/types/board'
 import { hasAtLeast } from '@/utils/auth/role'
-import { insertAtCursor } from '@/utils/insertAtCursor'
 
 const TEAM_OPTIONS: GdgDropdownOption[] = [
   { id: 'HQ', label: 'HQ' },
@@ -62,45 +55,16 @@ export default function EventBoardNewPage() {
   const [thumbnailUploading, setThumbnailUploading] = useState(false)
   const thumbnailInputRef = useRef<HTMLInputElement | null>(null)
 
-  const [contentImageUploading, setContentImageUploading] = useState(false)
-
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  const handleContentPaste = useCallback(
-    async (event: ClipboardEvent<HTMLTextAreaElement>) => {
-      const file = Array.from(event.clipboardData.files).find((item) =>
-        item.type.startsWith('image/')
-      )
-      // 이미지가 아니면 손대지 않는다 — 평범한 텍스트 붙여넣기가 그대로 동작해야 한다.
-      if (!file) return
-
-      // 붙여넣은 시점의 자리를 잡아 둔다. 업로드를 기다리는 사이 커서가 움직일 수 있다.
-      const { selectionStart, selectionEnd } = event.currentTarget
-      event.preventDefault()
-
-      const sizeError = validateUploadSize(file)
-      if (sizeError) {
-        setErrorMessage(sizeError)
-        return
-      }
-
-      setErrorMessage(null)
-      setContentImageUploading(true)
-      try {
-        const { uploadUrl } = await requestPresignedUpload(apiClient, file, THUMBNAIL_S3_KEY)
-        await uploadFileToS3(uploadUrl, file)
-        // 본문에는 서명이 붙지 않은 주소를 남긴다. presigned URL 은 5분이면 만료된다.
-        const markup = `![](${toPublicUrl(uploadUrl)})`
-        setContent((prev) => insertAtCursor(prev, selectionStart, selectionEnd, markup))
-      } catch (err) {
-        setErrorMessage(describeUploadError(err))
-      } finally {
-        setContentImageUploading(false)
-      }
-    },
-    [apiClient]
-  )
+  const { uploading: contentImageUploading, handlePaste: handleContentPaste } =
+    useContentImagePaste({
+      apiClient,
+      s3key: THUMBNAIL_S3_KEY,
+      setContent,
+      setErrorMessage
+    })
 
   const handleThumbnailSelect = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/app/board/free/detail/page.tsx
+++ b/src/app/board/free/detail/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 
 import { AttachmentList } from '@/components/board/AttachmentList'
+import { BoardContent } from '@/components/board/BoardContent'
 import { BOARD_MENUS } from '@/components/board/boardMenus'
 import { FreeBoardComments } from '@/components/board/FreeBoardComments'
 import { GdgSiteHeader } from '@/components/ui/design-system'
@@ -160,7 +161,7 @@ export default function FreeBoardDetailPage() {
           </div>
         </div>
 
-        <p className="whitespace-pre-wrap typo-pc-b2 mobile:typo-m-b2">{detail.content}</p>
+        <BoardContent content={detail.content} />
 
         <AttachmentList attachments={detail.attachments} />
 

--- a/src/app/board/free/edit/page.tsx
+++ b/src/app/board/free/edit/page.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/design-system'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
+import { useContentImagePaste } from '@/hooks/useContentImagePaste'
 import { fetchFreeDetail, updateFreePost } from '@/services/board/freeClient'
 import { hasAtLeast } from '@/utils/auth/role'
 
@@ -43,6 +44,9 @@ export default function FreeBoardEditPage() {
   const [attachments, setAttachments] = useState<AttachmentDraft[]>([])
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const { uploading: contentImageUploading, handlePaste: handleContentPaste } =
+    useContentImagePaste({ apiClient, s3key: FREE_S3_KEY, setContent, setErrorMessage })
 
   const isMember = hasAtLeast(user?.userRole, 'MEMBER')
 
@@ -173,13 +177,21 @@ export default function FreeBoardEditPage() {
           onChange={(event) => setTitle(event.target.value)}
         />
 
-        <GdgTextarea
-          label="내용"
-          fullWidth
-          rows={12}
-          value={content}
-          onChange={(event) => setContent(event.target.value)}
-        />
+        <div className="flex flex-col gap-2">
+          <GdgTextarea
+            label="내용"
+            fullWidth
+            rows={12}
+            value={content}
+            onChange={(event) => setContent(event.target.value)}
+            onPaste={handleContentPaste}
+          />
+          <p className="typo-pc-c1 mobile:typo-m-c1 text-gray-500">
+            {contentImageUploading
+              ? '이미지 올리는 중...'
+              : '이미지를 복사해 붙여넣으면 그 자리에 들어갑니다.'}
+          </p>
+        </div>
 
         <div className="flex flex-col gap-2">
           <span className="tracking-[0.2em] text-white/80 typo-pc-s3 mobile:typo-m-s3 uppercase">

--- a/src/app/board/free/new/page.tsx
+++ b/src/app/board/free/new/page.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/design-system'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
+import { useContentImagePaste } from '@/hooks/useContentImagePaste'
 import { createFreePost } from '@/services/board/freeClient'
 import { hasAtLeast } from '@/utils/auth/role'
 
@@ -31,6 +32,9 @@ export default function FreeBoardNewPage() {
   const [attachments, setAttachments] = useState<AttachmentDraft[]>([])
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const { uploading: contentImageUploading, handlePaste: handleContentPaste } =
+    useContentImagePaste({ apiClient, s3key: FREE_S3_KEY, setContent, setErrorMessage })
 
   const handleSubmit = useCallback(async () => {
     if (!title.trim() || !content.trim()) {
@@ -87,13 +91,21 @@ export default function FreeBoardNewPage() {
           onChange={(event) => setTitle(event.target.value)}
         />
 
-        <GdgTextarea
-          label="내용"
-          fullWidth
-          rows={12}
-          value={content}
-          onChange={(event) => setContent(event.target.value)}
-        />
+        <div className="flex flex-col gap-2">
+          <GdgTextarea
+            label="내용"
+            fullWidth
+            rows={12}
+            value={content}
+            onChange={(event) => setContent(event.target.value)}
+            onPaste={handleContentPaste}
+          />
+          <p className="typo-pc-c1 mobile:typo-m-c1 text-gray-500">
+            {contentImageUploading
+              ? '이미지 올리는 중...'
+              : '이미지를 복사해 붙여넣으면 그 자리에 들어갑니다.'}
+          </p>
+        </div>
 
         <div className="flex flex-col gap-2">
           <span className="tracking-[0.2em] text-white/80 typo-pc-s3 mobile:typo-m-s3 uppercase">

--- a/src/app/board/free/page.tsx
+++ b/src/app/board/free/page.tsx
@@ -80,7 +80,12 @@ export default function FreeBoardListPage() {
   }, [keyword])
 
   const columns: BoardListColumn<FreeBoardSummary>[] = [
-    { key: 'title', header: '제목', primary: true, render: (item) => item.title },
+    {
+      key: 'title',
+      header: '제목',
+      primary: true,
+      render: (item) => <span className="block truncate">{item.title}</span>
+    },
     { key: 'author', header: '작성자', render: (item) => item.authorName, className: 'w-32' },
     { key: 'view', header: '조회', render: (item) => item.viewCount, className: 'w-20' },
     {

--- a/src/app/board/notices/detail/page.tsx
+++ b/src/app/board/notices/detail/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 
 import { AttachmentList } from '@/components/board/AttachmentList'
+import { BoardContent } from '@/components/board/BoardContent'
 import { NoticeCategoryTag } from '@/components/board/NoticeCategoryTag'
 import { GdgSiteHeader } from '@/components/ui/design-system'
 import { BOARD_MENUS } from '@/components/board/boardMenus'
@@ -158,7 +159,7 @@ export default function NoticeBoardDetailPage() {
           </div>
         </div>
 
-        <p className="whitespace-pre-wrap typo-pc-b2 mobile:typo-m-b2">{detail.content}</p>
+        <BoardContent content={detail.content} />
 
         <AttachmentList attachments={detail.attachments} />
 

--- a/src/app/board/notices/edit/page.tsx
+++ b/src/app/board/notices/edit/page.tsx
@@ -16,6 +16,7 @@ import {
 import { BOARD_MENUS } from '@/components/board/boardMenus'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
+import { useContentImagePaste } from '@/hooks/useContentImagePaste'
 import { fetchNoticeDetail, updateNotice } from '@/services/board/noticeClient'
 import { NOTICE_CATEGORY_LABEL, type NoticeCategory } from '@/types/notice'
 import { hasAtLeast } from '@/utils/auth/role'
@@ -50,6 +51,9 @@ export default function NoticeBoardEditPage() {
   const [attachments, setAttachments] = useState<AttachmentDraft[]>([])
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const { uploading: contentImageUploading, handlePaste: handleContentPaste } =
+    useContentImagePaste({ apiClient, s3key: NOTICE_S3_KEY, setContent, setErrorMessage })
 
   const canManage = hasAtLeast(user?.userRole, 'CORE')
   // 남의 글이면 서버가 403 을 줄 것을 미리 알아내 폼 대신 안내를 띄운다.
@@ -198,13 +202,21 @@ export default function NoticeBoardEditPage() {
           onChange={(value) => setCategory(value as NoticeCategory)}
         />
 
-        <GdgTextarea
-          label="내용"
-          fullWidth
-          rows={12}
-          value={content}
-          onChange={(event) => setContent(event.target.value)}
-        />
+        <div className="flex flex-col gap-2">
+          <GdgTextarea
+            label="내용"
+            fullWidth
+            rows={12}
+            value={content}
+            onChange={(event) => setContent(event.target.value)}
+            onPaste={handleContentPaste}
+          />
+          <p className="typo-pc-c1 mobile:typo-m-c1 text-gray-500">
+            {contentImageUploading
+              ? '이미지 올리는 중...'
+              : '이미지를 복사해 붙여넣으면 그 자리에 들어갑니다.'}
+          </p>
+        </div>
 
         {/* 공개 중인 공지를 임시저장으로 되돌려도 상단 고정은 자동으로 풀리지 않는다.
             백엔드는 고정 '저장 시점'에만 미공개를 거부하고(PinnedNoticeService.replacePinned),

--- a/src/app/board/notices/new/page.tsx
+++ b/src/app/board/notices/new/page.tsx
@@ -16,6 +16,7 @@ import {
 import { BOARD_MENUS } from '@/components/board/boardMenus'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
+import { useContentImagePaste } from '@/hooks/useContentImagePaste'
 import { createNotice } from '@/services/board/noticeClient'
 import { NOTICE_CATEGORY_LABEL, type NoticeCategory } from '@/types/notice'
 import { hasAtLeast } from '@/utils/auth/role'
@@ -40,6 +41,9 @@ export default function NoticeBoardNewPage() {
   const [attachments, setAttachments] = useState<AttachmentDraft[]>([])
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const { uploading: contentImageUploading, handlePaste: handleContentPaste } =
+    useContentImagePaste({ apiClient, s3key: NOTICE_S3_KEY, setContent, setErrorMessage })
 
   const handleSubmit = useCallback(async () => {
     if (!title.trim() || !category || !content.trim()) {
@@ -110,13 +114,21 @@ export default function NoticeBoardNewPage() {
           onChange={(value) => setCategory(value as NoticeCategory)}
         />
 
-        <GdgTextarea
-          label="내용"
-          fullWidth
-          rows={12}
-          value={content}
-          onChange={(event) => setContent(event.target.value)}
-        />
+        <div className="flex flex-col gap-2">
+          <GdgTextarea
+            label="내용"
+            fullWidth
+            rows={12}
+            value={content}
+            onChange={(event) => setContent(event.target.value)}
+            onPaste={handleContentPaste}
+          />
+          <p className="typo-pc-c1 mobile:typo-m-c1 text-gray-500">
+            {contentImageUploading
+              ? '이미지 올리는 중...'
+              : '이미지를 복사해 붙여넣으면 그 자리에 들어갑니다.'}
+          </p>
+        </div>
 
         {/* 임시저장은 별도 status가 아니라 isPublished=false 하나로 표현된다 (백엔드 설계 §3). */}
         <label className="flex items-center gap-2 typo-pc-b3 mobile:typo-m-b3">

--- a/src/app/board/notices/page.tsx
+++ b/src/app/board/notices/page.tsx
@@ -102,7 +102,8 @@ export default function NoticeBoardListPage() {
       primary: true,
       render: (item) => (
         <span className="flex items-center gap-2">
-          {item.title}
+          {/* flex 자식은 기본 min-width:auto 라 min-w-0 없이는 줄어들지 않아 말줄임이 안 걸린다. */}
+          <span className="min-w-0 truncate">{item.title}</span>
           {/* 서버가 CORE 미만에게는 미공개 글을 아예 주지 않으므로, 이 배지가 보인다는 건
               보는 사람이 CORE 이상이라는 뜻이다. */}
           {!item.isPublished && <span className="shrink-0 text-gray-700 typo-pc-c2 mobile:typo-m-c2">임시저장</span>}

--- a/src/hooks/useContentImagePaste.ts
+++ b/src/hooks/useContentImagePaste.ts
@@ -1,0 +1,77 @@
+'use client'
+
+import type { AxiosInstance } from 'axios'
+import {
+  useCallback,
+  useState,
+  type ClipboardEvent,
+  type Dispatch,
+  type SetStateAction
+} from 'react'
+
+import {
+  describeUploadError,
+  requestPresignedUpload,
+  toPublicUrl,
+  uploadFileToS3,
+  validateUploadSize
+} from '@/services/board/uploadClient'
+import { insertAtCursor } from '@/utils/insertAtCursor'
+
+export interface UseContentImagePasteOptions {
+  apiClient: AxiosInstance
+  /** 게시판별 S3KeyType 이름 — boardNotice · boardFree · boardEvent */
+  s3key: string
+  setContent: Dispatch<SetStateAction<string>>
+  setErrorMessage: Dispatch<SetStateAction<string | null>>
+}
+
+/**
+ * 내용 칸에 이미지를 붙여넣으면 업로드하고 그 자리에 이미지 표기를 넣는다.
+ * 세 게시판의 작성·수정 화면이 같은 동작을 쓴다.
+ */
+export const useContentImagePaste = ({
+  apiClient,
+  s3key,
+  setContent,
+  setErrorMessage
+}: UseContentImagePasteOptions) => {
+  const [uploading, setUploading] = useState(false)
+
+  const handlePaste = useCallback(
+    async (event: ClipboardEvent<HTMLTextAreaElement>) => {
+      const file = Array.from(event.clipboardData.files).find((item) =>
+        item.type.startsWith('image/')
+      )
+      // 이미지가 아니면 손대지 않는다 — 평범한 텍스트 붙여넣기가 그대로 동작해야 한다.
+      if (!file) return
+
+      // 붙여넣은 시점의 자리를 잡아 둔다. 업로드를 기다리는 사이 커서가 움직일 수 있다.
+      const { selectionStart, selectionEnd } = event.currentTarget
+      event.preventDefault()
+
+      const sizeError = validateUploadSize(file)
+      if (sizeError) {
+        setErrorMessage(sizeError)
+        return
+      }
+
+      setErrorMessage(null)
+      setUploading(true)
+      try {
+        const { uploadUrl } = await requestPresignedUpload(apiClient, file, s3key)
+        await uploadFileToS3(uploadUrl, file)
+        // 본문에는 서명이 붙지 않은 주소를 남긴다. presigned URL 은 5분이면 만료된다.
+        const markup = `![](${toPublicUrl(uploadUrl)})`
+        setContent((prev) => insertAtCursor(prev, selectionStart, selectionEnd, markup))
+      } catch (err) {
+        setErrorMessage(describeUploadError(err))
+      } finally {
+        setUploading(false)
+      }
+    },
+    [apiClient, s3key, setContent, setErrorMessage]
+  )
+
+  return { uploading, handlePaste }
+}


### PR DESCRIPTION
## 요약

행사게시판에만 있던 본문 이미지 붙여넣기를 공지·자유게시판에도 넣고, 세 게시판의 목록 행 모양을 맞춘다.

## 변경

**붙여넣기 지원 확대** — 공지·자유의 작성·수정 화면에서 내용 칸에 이미지를 붙여넣으면 그 자리에 들어간다. 세 게시판이 같은 동작을 쓰게 되어 처리를 `useContentImagePaste` 훅으로 뽑았고, 행사게시판도 그 훅을 쓰도록 바꿨다(동작 동일, `s3key` 만 `boardNotice`·`boardFree`·`boardEvent` 로 갈림).

**공지·자유 상세를 `BoardContent` 로** — 두 화면은 본문을 순수 텍스트로 그리고 있었다. 이걸 바꾸지 않으면 붙여넣은 이미지가 `![](주소)` 라는 글자로 보인다.

**목록 제목 말줄임** — `table-fixed` 는 `BoardList` 공용이라 세 게시판에 이미 적용돼 있었지만, 공지·자유는 제목에 말줄임이 없어 긴 제목이 줄바꿈되며 행 높이가 글마다 달랐다. 공지는 제목과 '임시저장' 배지가 한 flex 안에 있어 제목 쪽에 `min-w-0` 을 함께 건다 — flex 자식은 기본 `min-width:auto` 라 이것 없이는 줄어들지 않는다.

## 검증

dev 에서 확인했다.

| | 공지사항 | 자유게시판 |
|---|---|---|
| `table-layout` | fixed | fixed |
| 제목 열 | 640px (최대) | 736px (최대) |
| 긴 제목 삽입 후 열 너비 | 불변 | 불변 |
| 말줄임 | 실제로 잘림 | 실제로 잘림 |
| 행 높이 | 45px | 45px |

작성 화면의 `onPaste` 핸들러와 안내 문구가 공지·자유 양쪽에 붙은 것, 상세가 `BoardContent` 로 렌더되는 것도 확인했다. `yarn build` · `yarn lint` 통과.

클립보드 조작은 자동화가 어려워 실제 붙여넣기 동작은 수동 확인이 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KqZ35KmwzfReH9eCNnSEE