### PR TITLE
코어 모집 일정을 새 날짜로 고친다

### DIFF
--- a/src/constant/recruitSchedule.ts
+++ b/src/constant/recruitSchedule.ts
@@ -41,11 +41,11 @@ export function formatKoreanPeriodShort(openAt: string, closeAt: string): string
 export const CORE_SCHEDULE = {
   /** 서버 응답을 못 받았을 때만 쓰는 대체값. 서버 설정(app.recruit.core.*)과 함께 고친다. */
   fallbackOpenAt: '2026-08-10T00:00:00+09:00',
-  fallbackCloseAt: '2026-08-23T23:59:59+09:00',
-  documentResult: '2026. 8. 23.(일)',
-  interview: '2026. 8. 24.(월) - 2026. 8. 30.(일)',
+  fallbackCloseAt: '2026-09-08T23:59:59+09:00',
+  documentResult: '2026. 9. 8.(화) 23:59',
+  interview: '2026. 9. 9.(수) - 2026. 9. 13.(일)',
   interviewNote: '※ 지원자 및 면접관 일정에 따라 마감 전 면접이 가능할 수 있습니다.',
-  finalResult: '2026. 8. 31.(월)',
+  finalResult: '2026. 9. 13.(일)',
   meetingNote: '※ 일정은 9월 내로 공지 드립니다.'
 } as const
 


### PR DESCRIPTION
## 요약

코어 모집 일정이 바뀌어 `src/constant/recruitSchedule.ts` 의 `CORE_SCHEDULE` 을 고친다.

```
서류 모집   8. 10.(월) - 9. 8.(화)
서류 결과   9. 8.(화) 23:59
면접 진행   9. 9.(수) - 9. 13.(일)
최종 발표   9. 13.(일)
```

## 왜 웹도 고쳐야 하나

`RecruitScheduleCard` 가 보여주는 네 줄 중 **서버가 주는 것은 첫 줄뿐이다.**

| 화면 | 출처 |
|---|---|
| 서류 지원 기간 | 서버 `/api/v1/recruit/core/period` 우선, 실패 시 `fallback*` |
| 서류 결과 발표 | `CORE_SCHEDULE.documentResult` — **웹 상수만** |
| 면접 진행 기간 | `CORE_SCHEDULE.interview` — **웹 상수만** |
| 최종 결과 발표 | `CORE_SCHEDULE.finalResult` — **웹 상수만** |

서버만 배포하면 게이팅은 9/8 로 늘어나지만 화면의 면접·발표 날짜는 8월로 남는다. `fallbackCloseAt` 은 서버 응답을 못 받았을 때의 대체값이라 서버 yml 과 같은 값으로 맞춘다.

## 배포 순서

**Server 를 먼저 올린다** (GDGoCINHA/24-2_GDGoC_Server#345). 기간이 먼저 늘어나야 지원이 끊기지 않는다.

## 검증

요일 표기는 손으로 적지 않고 `recruitSchedule.ts` 의 `toKst` 와 같은 방식으로 계산해 대조했다 — 8/10(월) · 9/8(화) · 9/9(수) · 9/13(일) 모두 일치한다. `yarn build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KqZ35KmwzfReH9eCNnSEE