### PR TITLE
release: 부원 상시 모집 표기 · 마이페이지 지원서 열람

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import Link from 'next/link'
 
+import ApplicationDetailModal from '@/components/profile/ApplicationDetailModal'
 import ApplicationStatus from '@/components/profile/ApplicationStatus'
 import ProfileCard from '@/components/profile/ProfileCard'
 import ProfileInfoSection from '@/components/profile/ProfileInfoSection'
@@ -11,11 +12,19 @@ import { useAuth } from '@/hooks/useAuth'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
 import {
   fetchMyCoreApplication,
+  fetchMyCoreApplicationDetail,
+  fetchMyMemberApplication,
   fetchMyProfile,
   updateMyProfile,
   updateMyProfileImage
 } from '@/services/profile/profileClient'
-import type { MyCoreApplication, UpdateProfilePayload, UserProfile } from '@/types/profile'
+import type {
+  MyCoreApplication,
+  MyCoreApplicationDetail,
+  MyMemberApplication,
+  UpdateProfilePayload,
+  UserProfile
+} from '@/types/profile'
 
 export default function ProfilePage() {
   const { apiClient } = useAuthenticatedApi()
@@ -23,6 +32,7 @@ export default function ProfilePage() {
 
   const [profile, setProfile] = useState<UserProfile | null>(null)
   const [application, setApplication] = useState<MyCoreApplication | null>(null)
+  const [memberApplication, setMemberApplication] = useState<MyMemberApplication | null>(null)
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [applicationLoading, setApplicationLoading] = useState(true)
@@ -31,6 +41,10 @@ export default function ProfilePage() {
   const [uploading, setUploading] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [imageError, setImageError] = useState<string | null>(null)
+  const [openedApplication, setOpenedApplication] = useState<'core' | 'member' | null>(null)
+  const [coreDetail, setCoreDetail] = useState<MyCoreApplicationDetail | null>(null)
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [detailError, setDetailError] = useState<string | null>(null)
 
   useEffect(() => {
     let alive = true
@@ -46,10 +60,16 @@ export default function ProfilePage() {
       }
     }
 
-    const loadApplication = async () => {
+    const loadApplications = async () => {
       try {
-        const data = await fetchMyCoreApplication(apiClient)
-        if (alive) setApplication(data)
+        const [core, member] = await Promise.all([
+          fetchMyCoreApplication(apiClient),
+          fetchMyMemberApplication(apiClient)
+        ])
+        if (alive) {
+          setApplication(core)
+          setMemberApplication(member)
+        }
       } catch {
         // 404(미지원)는 클라이언트가 이미 null로 돌려준다. 여기 오는 건 실제 실패다.
         if (alive) setApplicationError('지원 현황을 불러오지 못했습니다.')
@@ -59,7 +79,7 @@ export default function ProfilePage() {
     }
 
     void load()
-    void loadApplication()
+    void loadApplications()
 
     return () => {
       alive = false
@@ -125,6 +145,32 @@ export default function ProfilePage() {
     [apiClient, profile, syncAuthUser]
   )
 
+  // 목록 응답에는 문항 답변이 없어 상세를 따로 받는다. 한 번 받은 뒤에는 다시 부르지 않는다.
+  const openCoreDetail = useCallback(async () => {
+    if (!application) return
+    setDetailError(null)
+    setOpenedApplication('core')
+    if (coreDetail) return
+
+    setDetailLoading(true)
+    try {
+      const detail = await fetchMyCoreApplicationDetail(apiClient, application.applicationId)
+      setCoreDetail(detail)
+    } catch {
+      setDetailError('지원서를 불러오지 못했습니다.')
+    } finally {
+      setDetailLoading(false)
+    }
+  }, [apiClient, application, coreDetail])
+
+  // 부원 지원서는 목록 응답이 곧 상세다. 추가 호출이 필요 없다.
+  const openMemberDetail = useCallback(() => {
+    setDetailError(null)
+    setOpenedApplication('member')
+  }, [])
+
+  const closeDetail = useCallback(() => setOpenedApplication(null), [])
+
   if (loading) return <Loader isLoading />
   if (loadError) {
     return (
@@ -179,10 +225,24 @@ export default function ProfilePage() {
 
         <ApplicationStatus
           application={application}
+          memberApplication={memberApplication}
           loading={applicationLoading}
           error={applicationError}
+          onOpenCore={() => void openCoreDetail()}
+          onOpenMember={openMemberDetail}
         />
       </div>
+
+      {openedApplication !== null ? (
+        <ApplicationDetailModal
+          title={openedApplication === 'core' ? '운영진 지원서' : '부원 지원서'}
+          core={openedApplication === 'core' ? coreDetail : null}
+          member={openedApplication === 'member' ? memberApplication : null}
+          loading={detailLoading}
+          error={detailError}
+          onClose={closeDetail}
+        />
+      ) : null}
     </main>
   )
 }

--- a/src/app/recruit/member/completed/page.tsx
+++ b/src/app/recruit/member/completed/page.tsx
@@ -121,7 +121,12 @@ export default function RecruitSubmit() {
             <Card className="flex-col items-start gap-2">
               <Bullet>
                 <span className="font-bold mr-2">집중 모집 기간</span>
-                <span>{formatKoreanPeriod(MEMBER_SCHEDULE.openAt, MEMBER_SCHEDULE.closeAt)}</span>
+                <span>
+                  {formatKoreanPeriod(
+                    MEMBER_SCHEDULE.intensiveOpenAt,
+                    MEMBER_SCHEDULE.intensiveCloseAt
+                  )}
+                </span>
               </Bullet>
             </Card>
 

--- a/src/app/recruit/page.tsx
+++ b/src/app/recruit/page.tsx
@@ -29,19 +29,22 @@ export default function RecruitSelect() {
     ? formatKoreanPeriodShort(period.openAt, period.closeAt)
     : formatKoreanPeriodShort(CORE_SCHEDULE.fallbackOpenAt, CORE_SCHEDULE.fallbackCloseAt)
 
-  // 부원도 코어와 같은 규칙이다. 전에는 서버에 기간이 없어 항상 열어뒀다.
+  // 부원은 코어와 달리 상시 모집이다. 게이팅은 코어와 같은 규칙이지만 서버 close-at 이
+  // 학기 말까지 열려 있어, 카드에 그 값을 그대로 쓰면 '8. 17. ~ 1. 31.' 로 나온다.
+  // 그래서 날짜는 집중 모집 기간(MEMBER_SCHEDULE)을 보여주고 서버 응답은 상태 판정에만 쓴다.
   const memberUnknown = memberFailed || !memberPeriod
   const memberOpen = memberUnknown || memberPeriod.status === 'OPEN'
   const memberStatusLabel = memberUnknown
-    ? '모집중'
+    ? '상시 모집 중'
     : memberPeriod.status === 'OPEN'
-      ? '모집중'
+      ? '상시 모집 중'
       : memberPeriod.status === 'BEFORE_OPEN'
         ? `${formatKoreanDateShort(memberPeriod.openAt)} 오픈`
         : '모집 마감'
-  const memberPeriodText = memberPeriod
-    ? formatKoreanPeriodShort(memberPeriod.openAt, memberPeriod.closeAt)
-    : formatKoreanPeriodShort(MEMBER_SCHEDULE.openAt, MEMBER_SCHEDULE.closeAt)
+  const memberIntensivePeriodText = formatKoreanPeriodShort(
+    MEMBER_SCHEDULE.intensiveOpenAt,
+    MEMBER_SCHEDULE.intensiveCloseAt
+  )
 
   return (
     <main className="min-h-screen bg-black overflow-x-hidden">
@@ -66,7 +69,13 @@ export default function RecruitSelect() {
           <RecruitTypeCard
             title="Member"
             subtitle="부원"
-            period={memberPeriodText}
+            period={
+              <>
+                {memberIntensivePeriodText}{' '}
+                {/* 괄호 문구가 '(집중 모 / 집 기간)' 으로 쪼개지지 않게 통째로 넘긴다. */}
+                <span className="whitespace-nowrap">(집중 모집 기간)</span>
+              </>
+            }
             href="/recruit/member"
             statusLabel={memberStatusLabel}
             isOpen={memberOpen}

--- a/src/components/profile/ApplicationDetailModal.tsx
+++ b/src/components/profile/ApplicationDetailModal.tsx
@@ -1,0 +1,253 @@
+'use client'
+
+import { useEffect } from 'react'
+
+import { formatMajorLabel } from '@/constant/majorOptions'
+import type { MyCoreApplicationDetail, MyMemberApplication } from '@/types/profile'
+import { formatPhoneNumberDisplay } from '@/utils/phoneNumber'
+
+/** 서버 InputType enum 이름 → 지원 폼에 쓰인 문항 이름. 값이 없으면 원문을 그대로 보여준다. */
+const ANSWER_LABELS: Record<string, string> = {
+  INTERESTS: '관심 분야',
+  EXPECTED_ACTIVITY: '하고 싶은 활동',
+  FEEDBACK: '동아리 운영에 바라는 점',
+  PROOF_FILE: '증빙 서류',
+  APPLY_MOTIVATION: '지원 동기',
+  LIFE_STORY: '살아온 이야기',
+  GDG_PERIOD: '활동 기간',
+  ROUTE_TO_KNOW: '알게 된 경로',
+  WANT_TO_GET: '기대하는 것'
+}
+
+const ENROLLMENT_LABELS: Record<string, string> = {
+  FULL_REGISTRATION: '재학',
+  PARTIAL_REGISTRATION: '부분등록',
+  LEAVE_OF_ABSENCE: '휴학',
+  MILITARY_LEAVE: '군휴학',
+  COMPLETION: '수료',
+  GRADUATION: '졸업'
+}
+
+const GENDER_LABELS: Record<string, string> = {
+  MALE: '남성',
+  FEMALE: '여성',
+  PRIVATE: '비공개'
+}
+
+const formatDateTime = (value?: string | null) => {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+}
+
+/** 'Y26_2' → '2026-2학기' */
+const formatSemesterLabel = (value?: string | null) => {
+  if (!value) return '-'
+  const matched = /^Y(\d{2})_(\d)$/.exec(value)
+  return matched ? `20${matched[1]}-${matched[2]}학기` : value
+}
+
+const isFileUrl = (value: string) => value.startsWith('http://') || value.startsWith('https://')
+
+const formatAnswerValue = (value: unknown): string => {
+  if (value === null || value === undefined || value === '') return '-'
+  if (Array.isArray(value)) return value.length > 0 ? value.join(', ') : '-'
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex gap-3">
+      <span className="w-24 shrink-0 typo-pc-b3 text-gray-700 mobile:typo-m-b3">{label}</span>
+      <span className="break-all typo-pc-b3 text-white mobile:typo-m-b3">{value}</span>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-xl border border-white/10 bg-gray-100/30 p-4">
+      <p className="typo-pc-c2 text-gray-700">{title}</p>
+      <div className="mt-3">{children}</div>
+    </section>
+  )
+}
+
+function LongAnswer({ label, value }: { label: string; value: string }) {
+  return (
+    <Section title={label}>
+      <p className="whitespace-pre-wrap typo-pc-b3 text-white mobile:typo-m-b3">{value || '-'}</p>
+    </Section>
+  )
+}
+
+interface ApplicationDetailModalProps {
+  title: string
+  /** 둘 중 하나만 채운다. 로딩 중에는 둘 다 null 이다. */
+  core?: MyCoreApplicationDetail | null
+  member?: MyMemberApplication | null
+  loading?: boolean
+  error?: string | null
+  onClose: () => void
+}
+
+/**
+ * 마이페이지에서 내가 낸 지원서를 펼쳐 본다.
+ *
+ * 운영진 대시보드의 상세 모달과 겉모습은 닮았지만 그쪽은 합불 처리 UI 가 붙어 있어 재사용하지 않는다.
+ * 여기서는 읽기만 하며, 검토 메모·검토자는 서버가 애초에 내려주지 않는다.
+ */
+export default function ApplicationDetailModal({
+  title,
+  core = null,
+  member = null,
+  loading = false,
+  error = null,
+  onClose
+}: ApplicationDetailModalProps) {
+  // 모달이 떠 있는 동안 뒤 화면이 같이 스크롤되면 어디를 보고 있는지 잃는다.
+  useEffect(() => {
+    const previous = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previous
+    }
+  }, [])
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
+
+  const memberAnswers = member?.answers?.answers ?? []
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 py-6"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="max-h-full w-full max-w-[720px] overflow-y-auto rounded-2xl border border-white/10 bg-black p-6"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <h2 className="typo-pc-h4 text-white mobile:typo-m-h3">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="shrink-0 rounded-lg border border-white/10 px-3 py-2 typo-pc-c2 text-white transition hover:bg-white/5"
+          >
+            닫기
+          </button>
+        </div>
+
+        {loading ? <p className="mt-6 typo-pc-b3 text-gray-700">불러오는 중…</p> : null}
+        {error ? <p className="mt-6 typo-pc-b3 text-red">{error}</p> : null}
+
+        {core ? (
+          <div className="mt-6 space-y-4">
+            <Section title="기본 정보">
+              <div className="space-y-2">
+                <Field label="이름" value={core.snapshot.name} />
+                <Field label="학번" value={core.snapshot.studentId} />
+                <Field label="전공" value={formatMajorLabel(core.snapshot.major)} />
+                <Field label="전화번호" value={formatPhoneNumberDisplay(core.snapshot.phone)} />
+                <Field label="이메일" value={core.snapshot.email} />
+                <Field label="지원 팀" value={core.team} />
+                <Field label="제출 시각" value={formatDateTime(core.createdAt)} />
+              </div>
+            </Section>
+
+            <LongAnswer label="지원 동기" value={core.motivation} />
+            <LongAnswer label="하고 싶은 일" value={core.wish} />
+            <LongAnswer label="강점" value={core.strengths} />
+            <LongAnswer label="다짐" value={core.pledge} />
+
+            <Section title="첨부 파일">
+              {core.fileUrls.length > 0 ? (
+                <div className="space-y-2">
+                  {core.fileUrls.map((url) => (
+                    <a
+                      key={url}
+                      href={url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="block break-all typo-pc-b3 text-[#9EC0FF] underline"
+                    >
+                      {url}
+                    </a>
+                  ))}
+                </div>
+              ) : (
+                <p className="typo-pc-b3 text-gray-700">첨부 파일이 없습니다.</p>
+              )}
+            </Section>
+          </div>
+        ) : null}
+
+        {member ? (
+          <div className="mt-6 space-y-4">
+            <Section title="기본 정보">
+              <div className="space-y-2">
+                <Field label="이름" value={member.name} />
+                <Field label="학번" value={member.studentId} />
+                <Field label="전공" value={formatMajorLabel(member.major)} />
+                <Field
+                  label="재학 상태"
+                  value={ENROLLMENT_LABELS[member.enrolledClassification ?? ''] ?? '-'}
+                />
+                <Field label="성별" value={GENDER_LABELS[member.gender ?? ''] ?? '-'} />
+                <Field label="생년월일" value={member.birth ?? '-'} />
+                <Field label="전화번호" value={formatPhoneNumberDisplay(member.phoneNumber)} />
+                <Field label="이메일" value={member.email} />
+                <Field label="지원 학기" value={formatSemesterLabel(member.admissionSemester)} />
+                <Field label="제출 시각" value={formatDateTime(member.createdAt)} />
+                <Field label="회비 입금" value={member.isPayed ? '입금 완료' : '미입금'} />
+              </div>
+            </Section>
+
+            {memberAnswers.map((answer) => {
+              const label = ANSWER_LABELS[answer.inputType] ?? answer.inputType
+              const value = answer.responseValue
+
+              if (
+                answer.inputType === 'PROOF_FILE' &&
+                typeof value === 'string' &&
+                isFileUrl(value)
+              ) {
+                return (
+                  <Section key={answer.id} title={label}>
+                    <a
+                      href={value}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="block break-all typo-pc-b3 text-[#9EC0FF] underline"
+                    >
+                      {value}
+                    </a>
+                  </Section>
+                )
+              }
+
+              return <LongAnswer key={answer.id} label={label} value={formatAnswerValue(value)} />
+            })}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/components/profile/ApplicationStatus.tsx
+++ b/src/components/profile/ApplicationStatus.tsx
@@ -1,6 +1,10 @@
 'use client'
 
-import type { ApplicationStatusValue, MyCoreApplication } from '@/types/profile'
+import type {
+  ApplicationStatusValue,
+  MyCoreApplication,
+  MyMemberApplication
+} from '@/types/profile'
 import { cn } from '@/utils/cn'
 
 const STATUS_CLASS: Record<ApplicationStatusValue, string> = {
@@ -17,17 +21,54 @@ const STATUS_LABEL: Record<ApplicationStatusValue, string> = {
   REJECTED: 'REJECTED'
 }
 
+/** 클릭하면 지원서 내용을 펼친다. 전에는 상태만 보이고 눌러도 아무 일이 없었다. */
+function ApplicationRow({
+  label,
+  statusLabel,
+  statusClass,
+  onClick
+}: {
+  label: string
+  statusLabel: string
+  statusClass: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full items-center overflow-hidden rounded-full bg-gray-100/30 text-left transition hover:bg-gray-100/50"
+    >
+      <span className="flex-1 px-5 py-3 typo-pc-b3 text-gray-700">{label}</span>
+      <span className="px-2 typo-pc-c2 text-gray-700" aria-hidden>
+        내용 보기
+      </span>
+      <span className={cn('min-w-[140px] px-5 py-3 text-center typo-pc-b3', statusClass)}>
+        {statusLabel}
+      </span>
+    </button>
+  )
+}
+
 interface ApplicationStatusProps {
   application: MyCoreApplication | null
+  memberApplication: MyMemberApplication | null
   loading?: boolean
   error?: string | null
+  onOpenCore: () => void
+  onOpenMember: () => void
 }
 
 export default function ApplicationStatus({
   application,
+  memberApplication,
   loading = false,
-  error = null
+  error = null,
+  onOpenCore,
+  onOpenMember
 }: ApplicationStatusProps) {
+  const hasAny = application !== null || memberApplication !== null
+
   return (
     <section className="space-y-4">
       <h2 className="typo-pc-h4 text-white">활동 및 신청 현황</h2>
@@ -36,17 +77,26 @@ export default function ApplicationStatus({
         <p className="typo-pc-b3 text-gray-700">불러오는 중…</p>
       ) : error ? (
         <p className="typo-pc-b3 text-red">{error}</p>
-      ) : application ? (
-        <div className="flex items-center overflow-hidden rounded-full bg-gray-100/30">
-          <span className="flex-1 px-5 py-3 typo-pc-b3 text-gray-700">운영진 지원서</span>
-          <span
-            className={cn(
-              'min-w-[140px] px-5 py-3 text-center typo-pc-b3',
-              STATUS_CLASS[application.resultStatus]
-            )}
-          >
-            {STATUS_LABEL[application.resultStatus]}
-          </span>
+      ) : hasAny ? (
+        <div className="space-y-3">
+          {application ? (
+            <ApplicationRow
+              label="운영진 지원서"
+              statusLabel={STATUS_LABEL[application.resultStatus]}
+              statusClass={STATUS_CLASS[application.resultStatus]}
+              onClick={onOpenCore}
+            />
+          ) : null}
+
+          {/* 부원 지원에는 합불 판정이 없다. 상태 칸은 제출 사실만 알린다. */}
+          {memberApplication ? (
+            <ApplicationRow
+              label="부원 지원서"
+              statusLabel="제출 완료"
+              statusClass={STATUS_CLASS.SUBMITTED}
+              onClick={onOpenMember}
+            />
+          ) : null}
         </div>
       ) : (
         <p className="typo-pc-b3 text-gray-700">제출한 지원서가 없습니다.</p>

--- a/src/components/recruit/RecruitTypeCard.tsx
+++ b/src/components/recruit/RecruitTypeCard.tsx
@@ -7,7 +7,8 @@ import { cn } from '@/utils/cn'
 type Props = {
   title: string
   subtitle: string
-  period: string
+  /** 문자열 외에 부가 문구를 붙일 수 있게 노드로 받는다 — 부원 카드가 '(집중 모집 기간)' 을 단다. */
+  period: React.ReactNode
   href: string
   statusLabel: string
   isOpen: boolean

--- a/src/constant/recruitSchedule.ts
+++ b/src/constant/recruitSchedule.ts
@@ -49,8 +49,15 @@ export const CORE_SCHEDULE = {
   meetingNote: '※ 일정은 9월 내로 공지 드립니다.'
 } as const
 
+/**
+ * 부원 모집은 **상시 모집**이다. 아래 두 값은 화면에 안내하는 **집중 모집 기간**일 뿐,
+ * 지원 가능 여부와는 무관하다 — 게이팅은 서버가 `app.recruit.member.*` 로 판정하고
+ * 그 close-at 은 학기 말까지 열려 있다.
+ *
+ * 그래서 여기 값을 서버 응답의 대체값으로 쓰지 않는다. 서버 기간을 그대로 그리면
+ * 카드에 '8. 17.(월) ~ 1. 31.(일)' 이 뜬다.
+ */
 export const MEMBER_SCHEDULE = {
-  /** 서버 응답을 못 받았을 때만 쓰는 대체값. 서버 설정(app.recruit.member.*)과 함께 고친다. */
-  openAt: '2026-08-17T00:00:00+09:00',
-  closeAt: '2026-09-09T23:59:59+09:00'
+  intensiveOpenAt: '2026-08-17T00:00:00+09:00',
+  intensiveCloseAt: '2026-09-09T23:59:59+09:00'
 } as const

--- a/src/services/profile/profileClient.ts
+++ b/src/services/profile/profileClient.ts
@@ -1,6 +1,12 @@
 import axios, { type AxiosInstance } from 'axios'
 
-import type { MyCoreApplication, UpdateProfilePayload, UserProfile } from '@/types/profile'
+import type {
+  MyCoreApplication,
+  MyCoreApplicationDetail,
+  MyMemberApplication,
+  UpdateProfilePayload,
+  UserProfile
+} from '@/types/profile'
 import { unwrapApiResponse } from '@/utils/api/unwrap'
 
 export const fetchMyProfile = async (apiClient: AxiosInstance): Promise<UserProfile> => {
@@ -38,6 +44,41 @@ export const fetchMyCoreApplication = async (
   try {
     const response = await apiClient.get<MyCoreApplication>('/recruit/core/applications/me')
     return response.data ?? null
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      return null
+    }
+    throw error
+  }
+}
+
+/**
+ * 운영진 지원서 상세. 목록 응답(fetchMyCoreApplication)에는 문항 답변이 없다.
+ *
+ * 본인/운영진만 열 수 있으며 서버가 판정한다. 본인이 볼 때는 검토 메모가 빠져서 온다.
+ * 이 엔드포인트도 ApiResponse 래퍼 없이 DTO 를 직접 반환한다.
+ */
+export const fetchMyCoreApplicationDetail = async (
+  apiClient: AxiosInstance,
+  applicationId: number
+): Promise<MyCoreApplicationDetail> => {
+  const response = await apiClient.get<MyCoreApplicationDetail>(
+    `/recruit/core/applications/${applicationId}`
+  )
+  return response.data
+}
+
+/**
+ * 부원 지원서 조회.
+ * 부원 지원은 비로그인으로 받으므로 서버가 로그인 계정의 이메일로 지원서를 찾는다.
+ * 404(지원 이력 없음)면 null 을 반환하고, 그 외 에러는 호출자에게 던진다.
+ */
+export const fetchMyMemberApplication = async (
+  apiClient: AxiosInstance
+): Promise<MyMemberApplication | null> => {
+  try {
+    const response = await apiClient.get('/recruit/member/applications/me')
+    return unwrapApiResponse<MyMemberApplication>(response.data)
   } catch (error) {
     if (axios.isAxiosError(error) && error.response?.status === 404) {
       return null

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -31,3 +31,53 @@ export interface MyCoreApplication {
   team: string
   resultStatus: ApplicationStatusValue
 }
+
+export interface MyCoreApplicationDetail {
+  applicationId: number
+  session: string
+  snapshot: {
+    name: string
+    studentId: string
+    phone: string
+    major: string
+    email: string
+  }
+  team: string
+  motivation: string
+  wish: string
+  strengths: string
+  pledge: string
+  fileUrls: string[]
+  resultStatus: ApplicationStatusValue
+  createdAt: string
+  updatedAt: string
+}
+
+export interface MemberApplicationAnswer {
+  id: number
+  /** 서버 InputType enum 의 이름 — 'INTERESTS' 처럼 온다. 폼의 키(gdgInterest)가 아니다. */
+  inputType: string
+  responseValue: unknown
+}
+
+/**
+ * 부원 지원서. 서버 SpecifiedMemberResponse 와 같은 모양이다.
+ *
+ * 코어와 달리 심사 상태가 없다 — 부원 지원은 합불 판정을 하지 않는다.
+ */
+export interface MyMemberApplication {
+  id: number
+  name: string
+  enrolledClassification: string | null
+  phoneNumber: string
+  email: string
+  gender: string | null
+  birth: string | null
+  major: string
+  studentId: string
+  admissionSemester: string | null
+  isPayed: boolean
+  createdAt: string
+  updatedAt: string
+  answers: { answers: MemberApplicationAnswer[] } | null
+}


### PR DESCRIPTION
## 무엇을 바꾸나

### 1. 부원 카드를 상시 모집으로 표기 (`/recruit`)
부원 모집은 상시 모집이고 8/17~9/9 는 집중 모집 기간인데, 카드는 `모집중` 이라고만 적어 마감일이 지나면 못 내는 것처럼 읽혔다.

- 라벨 `모집중` → **`상시 모집 중`**
- 날짜 옆에 **`(집중 모집 기간)`** 추가 (`whitespace-nowrap` 으로 묶는다 — 좁은 카드에서 `(집중 모 / 집 기간)` 으로 쪼개진다)
- 날짜 출처를 서버 `/period` 에서 `MEMBER_SCHEDULE` 상수로 옮긴다. 서버 `close-at` 이 학기 말까지 열려 있어 그대로 그리면 `8. 17.(월) ~ 1. 31.(일)` 이 나온다. 서버 응답은 이제 상태 판정에만 쓴다.

### 2. 마이페이지에서 제출한 지원서 열람 (`/profile`)
「활동 및 신청 현황」이 상태 배지만 보여 줬고 눌러도 아무 일이 없었다. 두 줄을 버튼으로 바꾸고 모달로 상세를 펼친다.

- **운영진 지원서** — 목록 응답에 문항 답변이 없어 상세를 따로 받는다. 한 번 받으면 다시 부르지 않는다.
- **부원 지원서** — 줄 자체가 새로 생겼다. 서버가 로그인 계정 이메일로 지원서를 찾아 준다. 합불 판정이 없어 상태 칸은 `제출 완료`.

## 검증

- `yarn build` 통과, `yarn lint` 통과 (신규 경고 없음)
- 로컬 화면 확인: `/recruit` 카드가 `상시 모집 중` + `(집중 모집 기간)` 으로 정상 렌더
- dev 실측: `/recruit/` HTML 에 두 문구 노출, profile 청크에 `부원 지원서` 포함

## 선행 조건

**Server PR #346 이 먼저 반영돼야 한다.** 마이페이지의 부원 지원서 줄이 `GET /api/v1/recruit/member/applications/me` 를 호출한다. 서버가 없으면 404 를 「지원서 없음」으로 처리해 줄이 안 보인다(크래시는 아님).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5AG5zJdauvLokhn5afovy