### PR TITLE
feat: 부원 지원자 목록에 제출 시각 컬럼을 넣는다

### DIFF
--- a/src/app/dashboard/members/page.tsx
+++ b/src/app/dashboard/members/page.tsx
@@ -18,6 +18,7 @@ type RecruitMemberSummary = {
   studentId: string
   admissionSemester: string | null
   isPayed: boolean
+  createdAt?: string
 }
 
 type RecruitMemberDetail = {
@@ -87,6 +88,23 @@ function currentAdmissionSemester(): string {
   const yy = month === 1 ? (year - 1) % 100 : year % 100
   const term = month === 1 ? 2 : month <= 7 ? 1 : 2
   return `Y${String(yy).padStart(2, '0')}_${term}`
+}
+
+/**
+ * 제출 시각. 목록의 기본 정렬이 createdAt DESC 이므로 이 칸이 정렬 기준을 눈으로 확인시켜 준다.
+ * 서버는 Instant(UTC)로 내려주고 toLocaleString 이 보는 사람의 시간대로 옮긴다.
+ */
+function formatSubmittedAt(value?: string | null): string {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString('ko-KR', {
+    year: '2-digit',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
 }
 
 /** 'Y26_2' → '2026-2학기' */
@@ -294,13 +312,14 @@ export default function DashboardMembersPage() {
         ) : null}
 
         <div className="overflow-x-auto rounded-xl border border-white/10">
-          <table className="w-full min-w-[820px] border-collapse">
+          <table className="w-full min-w-[960px] border-collapse">
             <thead>
               <tr className="bg-gray-100 text-left">
                 <th className="px-4 py-3 typo-pc-b3 text-gray-700">이름</th>
                 <th className="px-4 py-3 typo-pc-b3 text-gray-700">학과</th>
                 <th className="px-4 py-3 typo-pc-b3 text-gray-700">학번</th>
                 <th className="px-4 py-3 typo-pc-b3 text-gray-700">지원 학기</th>
+                <th className="px-4 py-3 typo-pc-b3 text-gray-700">제출 시각</th>
                 <th className="px-4 py-3 typo-pc-b3 text-gray-700">전화번호</th>
                 <th className="px-4 py-3 typo-pc-b3 text-gray-700">회비</th>
                 <th className="px-4 py-3 typo-pc-b3 text-gray-700">상세</th>
@@ -309,7 +328,7 @@ export default function DashboardMembersPage() {
             <tbody>
               {members.length === 0 ? (
                 <tr>
-                  <td colSpan={7} className="px-4 py-8 text-center typo-pc-b3 text-gray-700">
+                  <td colSpan={8} className="px-4 py-8 text-center typo-pc-b3 text-gray-700">
                     조회된 지원자가 없습니다.
                   </td>
                 </tr>
@@ -321,6 +340,9 @@ export default function DashboardMembersPage() {
                     <td className="px-4 py-3 typo-pc-b3">{member.studentId}</td>
                     <td className="px-4 py-3 typo-pc-b3">
                       {formatSemesterLabel(member.admissionSemester)}
+                    </td>
+                    <td className="px-4 py-3 typo-pc-b3 whitespace-nowrap">
+                      {formatSubmittedAt(member.createdAt)}
                     </td>
                     <td className="px-4 py-3 typo-pc-b3">
                       {formatPhoneNumberDisplay(member.phoneNumber)}


### PR DESCRIPTION
## 문제

부원 지원자가 언제 지원했는지 확인할 방법이 화면 어디에도 없었다.

- 목록은 최신순 정렬이라 **순서만** 알 수 있었다.
- 상세 모달은 `createdAt` 을 `RESERVED_KEYS` 로 걸러 표시하지 않는다 (`UserDetailsModal.tsx:37`).

## 고친 것

지원자 목록에 「제출 시각」 컬럼을 「지원 학기」 옆에 넣는다. 목록이 원래 `createdAt DESC` 로 정렬되므로 이 칸이 정렬 기준을 눈으로 확인시켜 준다.

- 표시 형식 `25. 08. 18. 12:34` — 서버는 Instant(UTC)로 주고 `toLocaleString` 이 보는 사람의 시간대로 옮긴다.
- 컬럼이 하나 늘어 테이블 최소 폭을 820px → 960px 로 올린다.

## 선행 조건

**Server PR #348 이 먼저 반영돼야 한다.** 그쪽이 `RecruitMemberSummaryResponse` 에 `createdAt` 을 담는다. 없으면 컬럼이 전부 `-` 로 보인다.

## 검증

- `yarn build` 통과, `yarn lint` 신규 경고 없음
- dev 실측: `dashboard/members` 청크에 「제출 시각」 포함, 화면 확인 완료

## 포맷

이 파일은 원래부터 Prettier 기준이 아니다(`SEMESTER_OPTIONS` 배열이 손으로 정렬돼 있음). `--write` 를 돌리면 무관한 22줄이 딸려오므로 돌리지 않았다. **추가한 줄은 Prettier 출력과 일치하는 것을 확인했다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5AG5zJdauvLokhn5afovy