### PR TITLE
feat: 입금 상태 변경에 확인 절차 추가

### DIFF
--- a/src/app/dashboard/members/page.tsx
+++ b/src/app/dashboard/members/page.tsx
@@ -176,7 +176,29 @@ export default function DashboardMembersPage() {
     setQuestion(searchInput)
   }
 
-  const handleTogglePay = async (memberId: number, nextState: boolean) => {
+  // 입금 체크는 계정 역할까지 바꾼다 — 서버가 GUEST↔MEMBER 를 함께 옮긴다.
+  // 한 번의 오클릭이 권한 변경으로 이어지므로 무엇이 바뀌는지 보여주고 확인을 받는다.
+  const confirmPayChange = (memberName: string, nextState: boolean) => {
+    const message = nextState
+      ? `${memberName} 님을 '입금 완료'로 변경합니다.
+
+` +
+        `가입한 계정이 GUEST 라면 MEMBER 로 승격되어 자유게시판에 글을 쓸 수 있게 됩니다.
+
+계속할까요?`
+      : `${memberName} 님을 '미입금'으로 변경합니다.
+
+` +
+        `가입한 계정이 MEMBER 라면 GUEST 로 내려갑니다. (CORE 이상은 바뀌지 않습니다)
+
+계속할까요?`
+
+    return window.confirm(message)
+  }
+
+  const handleTogglePay = async (memberId: number, memberName: string, nextState: boolean) => {
+    if (!confirmPayChange(memberName, nextState)) return
+
     try {
       setPayUpdatingMemberId(memberId)
       await apiClient.patch(`/recruit/member/${memberId}/payment`, { isPayed: nextState })
@@ -362,7 +384,7 @@ export default function DashboardMembersPage() {
                               className="typo-pc-c2"
                               onClick={() => {
                                 if (!isDisabled && member.isPayed !== segment.value) {
-                                  void handleTogglePay(member.id, segment.value)
+                                  void handleTogglePay(member.id, member.name, segment.value)
                                 }
                               }}
                             >


### PR DESCRIPTION
## 배경

`/dashboard/members`의 입금 세그먼트 버튼은 **한 번 누르면 바로 반영**됐다.

서버가 입금 체크에 맞춰 계정 역할까지 옮기게 되면서 (GDGoCINHA/24-2_GDGoC_Server#349), 오클릭 한 번이 곧 권한 변경이 된다.

## 변경

무엇이 함께 바뀌는지 문구에 담아 확인을 받는다.

- **입금 완료** → GUEST 계정이 MEMBER로 승격되어 자유게시판에 글을 쓸 수 있게 된다는 것을 알린다
- **미입금** → MEMBER가 GUEST로 내려가되 **CORE 이상은 바뀌지 않는다**는 것을 알린다

이 페이지가 이미 `alert`을 쓰고 있어 `confirm`으로 맞췄다. 별도 모달 컴포넌트를 새로 만들지 않았다.

## 배포 순서

**Server PR을 먼저 배포한 뒤 이걸 올린다.** 확인 문구가 서버의 역할 연동을 전제하므로, 서버가 구버전이면 안내가 사실과 달라진다.

관련: GDGoCINHA/24-2_GDGoC_Server#349

## 검증

`npx --yes yarn@1.22.22 build` 통과. `yarn.lock` 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164CPboxMhVFrADNjFhhUiy
