### PR TITLE
feat(landing): 소개글·문의 창구·모집 안내 일정을 관리자 화면에서 연다

### DIFF
--- a/src/app/recruit/member/completed/page.tsx
+++ b/src/app/recruit/member/completed/page.tsx
@@ -3,7 +3,8 @@
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { GdgLogo } from '@/components/ui/design-system'
-import { MEMBER_SCHEDULE, formatKoreanPeriod } from '@/constant/recruitSchedule'
+import { formatKoreanPeriod } from '@/constant/recruitSchedule'
+import { useMemberSchedule } from '@/hooks/useRecruitSchedule'
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -88,6 +89,7 @@ function CoreMemberPromoSection() {
 export default function RecruitSubmit() {
   const searchParams = useSearchParams()
   const isFromRecruit = searchParams.get('from') === 'recruit'
+  const memberSchedule = useMemberSchedule()
 
   return (
     <main className="mx-auto w-full max-w-[760px] px-[clamp(20px,5vw,44px)] pb-[100px] pt-14">
@@ -112,8 +114,8 @@ export default function RecruitSubmit() {
               <span className="mr-2 font-medium text-dusk-ink-100">집중 모집 기간</span>
               <span>
                 {formatKoreanPeriod(
-                  MEMBER_SCHEDULE.intensiveOpenAt,
-                  MEMBER_SCHEDULE.intensiveCloseAt
+                  memberSchedule.intensiveOpenAt,
+                  memberSchedule.intensiveCloseAt
                 )}
               </span>
             </Bullet>

--- a/src/app/recruit/page.tsx
+++ b/src/app/recruit/page.tsx
@@ -6,9 +6,9 @@ import { useRecruitCorePeriod } from '@/hooks/useRecruitCorePeriod'
 import { useRecruitMemberPeriod } from '@/hooks/useRecruitMemberPeriod'
 import {
   CORE_SCHEDULE,
-  MEMBER_SCHEDULE,
   formatKoreanDateShort,
-  formatKoreanPeriodShort
+  formatKoreanPeriodShort,
+  resolveMemberSchedule
 } from '@/constant/recruitSchedule'
 
 export default function RecruitSelect() {
@@ -41,9 +41,10 @@ export default function RecruitSelect() {
       : memberPeriod.status === 'BEFORE_OPEN'
         ? `${formatKoreanDateShort(memberPeriod.openAt)} 오픈`
         : '모집 마감'
+  const memberSchedule = resolveMemberSchedule(memberPeriod?.notice)
   const memberIntensivePeriodText = formatKoreanPeriodShort(
-    MEMBER_SCHEDULE.intensiveOpenAt,
-    MEMBER_SCHEDULE.intensiveCloseAt
+    memberSchedule.intensiveOpenAt,
+    memberSchedule.intensiveCloseAt
   )
 
   return (

--- a/src/components/admin/landing/LandingAdmin.tsx
+++ b/src/components/admin/landing/LandingAdmin.tsx
@@ -4,14 +4,16 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { SchedulePanel } from '@/components/admin/landing/SchedulePanel'
 import {
+  AboutPanel,
   ActivitiesPanel,
+  ContactPanel,
   FaqPanel,
   HackathonsPanel,
   HeroPanel,
   PhotoStripPanel
 } from '@/components/admin/landing/panels'
 import { DUSK_GHOST_BUTTON, DUSK_PRIMARY_BUTTON } from '@/components/ui/dusk/DuskForm'
-import { LANDING_CONTENT_FALLBACK } from '@/constant/landingContent'
+import { LANDING_CONTENT_FALLBACK, mergeLandingContent } from '@/constant/landingContent'
 import { useAuthenticatedApi } from '@/hooks/useAuthenticatedApi'
 import {
   fetchLandingDraft,
@@ -21,15 +23,25 @@ import {
 import type { LandingContentDocument } from '@/types/landing'
 import { cn } from '@/utils/cn'
 
-type TabId = 'hero' | 'strip' | 'activities' | 'hackathons' | 'schedule' | 'faq'
+type TabId =
+  | 'hero'
+  | 'about'
+  | 'strip'
+  | 'activities'
+  | 'hackathons'
+  | 'schedule'
+  | 'faq'
+  | 'contact'
 
 const TABS: { id: TabId; label: string }[] = [
   { id: 'hero', label: '히어로' },
+  { id: 'about', label: '소개' },
   { id: 'strip', label: '사진 띠' },
   { id: 'activities', label: '활동' },
   { id: 'hackathons', label: '대회 · 해커톤' },
   { id: 'schedule', label: '모집 일정' },
-  { id: 'faq', label: 'FAQ' }
+  { id: 'faq', label: 'FAQ' },
+  { id: 'contact', label: '문의 · 학기' }
 ]
 
 /**
@@ -71,8 +83,11 @@ export default function LandingAdmin() {
     fetchLandingDraft(apiClient)
       .then((draft) => {
         // 서버에 아무것도 없으면 번들 기본값에서 시작한다. 빈 화면을 주면 처음 쓰는
-        // 사람이 여섯 탭을 전부 채워야 한다.
-        if (alive && draft) setDocument(draft)
+        // 사람이 여덟 탭을 전부 채워야 한다.
+        //
+        // 있더라도 통째로 갈아끼우지 않는다 — 소개·문의·학기 라벨이 늘기 전에 저장된
+        // 초안에는 그 칸이 없어서, 그대로 넣으면 편집 화면이 빈 값으로 깨진다.
+        if (alive && draft) setDocument(mergeLandingContent(draft))
       })
       .catch(() => {
         if (alive) setError('초안을 불러오지 못했습니다. 기본값에서 시작합니다.')
@@ -128,11 +143,13 @@ export default function LandingAdmin() {
 
   const counts: Record<TabId, string> = {
     hero: '사진 1',
+    about: `${document.about.values.length}칸`,
     strip: `사진 ${document.photoStrip.length}`,
     activities: `${document.activities.length}개`,
     hackathons: `${document.hackathons.length}개`,
     schedule: '2종',
-    faq: `${document.faqs.length}개`
+    faq: `${document.faqs.length}개`,
+    contact: document.semesterLabel
   }
 
   if (loading) {
@@ -198,7 +215,7 @@ export default function LandingAdmin() {
             ))}
           </nav>
 
-          {/* 탭이 여섯 개라 좁은 화면에서는 끝이 잘린다. 잘린 글자만 보이면 더 있는 줄
+          {/* 탭이 여덟 개라 좁은 화면에서는 끝이 잘린다. 잘린 글자만 보이면 더 있는 줄
               모르고 지나치므로, 오른쪽에 그라데이션을 덮어 옆으로 더 있다고 알린다.
               끝까지 밀면 사라진다 — 남아 있으면 없는 탭이 있다고 거짓말하는 셈이다. */}
           {tabsOverflow && (
@@ -213,6 +230,9 @@ export default function LandingAdmin() {
           {tab === 'hero' && (
             <HeroPanel document={document} onChange={change} apiClient={apiClient} />
           )}
+          {tab === 'about' && (
+            <AboutPanel document={document} onChange={change} apiClient={apiClient} />
+          )}
           {tab === 'strip' && (
             <PhotoStripPanel document={document} onChange={change} apiClient={apiClient} />
           )}
@@ -225,6 +245,9 @@ export default function LandingAdmin() {
           {tab === 'schedule' && <SchedulePanel apiClient={apiClient} />}
           {tab === 'faq' && (
             <FaqPanel document={document} onChange={change} apiClient={apiClient} />
+          )}
+          {tab === 'contact' && (
+            <ContactPanel document={document} onChange={change} apiClient={apiClient} />
           )}
         </div>
       </div>

--- a/src/components/admin/landing/SchedulePanel.tsx
+++ b/src/components/admin/landing/SchedulePanel.tsx
@@ -1,14 +1,16 @@
 'use client'
 
 import type { AxiosInstance } from 'axios'
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import {
   DuskField,
   DUSK_CANCEL_BUTTON,
   DUSK_INPUT,
-  DUSK_PRIMARY_BUTTON
+  DUSK_PRIMARY_BUTTON,
+  DUSK_TEXTAREA
 } from '@/components/ui/dusk/DuskForm'
+import type { RecruitScheduleNotice } from '@/constant/recruitSchedule'
 import {
   clearRecruitPeriod,
   fetchRecruitPeriod,
@@ -20,7 +22,8 @@ import type { RecruitPeriodAdmin, RecruitType } from '@/types/landing.admin'
  * `datetime-local` 은 시간대 없는 문자열을 다룬다. 서버는 Instant(UTC)를 주고받으므로
  * 브라우저 시간대 기준으로 서로 바꾼다 — 운영진이 한국에서 쓰는 값이라 KST 로 읽힌다.
  */
-const toLocalInput = (iso: string): string => {
+const toLocalInput = (iso: string | null | undefined): string => {
+  if (!iso) return ''
   const date = new Date(iso)
   if (Number.isNaN(date.getTime())) return ''
   const pad = (n: number) => String(n).padStart(2, '0')
@@ -34,6 +37,106 @@ const TYPE_LABEL: Record<RecruitType, string> = {
   MEMBER: '부원 모집'
 }
 
+/**
+ * 안내 일정 입력칸. 전부 문자열로 들고 있다가 저장할 때만 ISO 로 바꾼다.
+ *
+ * 비어 있는 칸은 비운 채로 저장한다 — 지웠다는 뜻이라, 예전 값을 남겨두면 화면에서 지운
+ * 날짜가 계속 보인다. 비면 방문자 화면은 배포에 들어 있는 기본값을 그린다.
+ */
+type NoticeForm = {
+  documentResultAt: string
+  interviewOpenAt: string
+  interviewCloseAt: string
+  finalResultAt: string
+  interviewNote: string
+  meetingNote: string
+  intensiveOpenAt: string
+  intensiveCloseAt: string
+}
+
+const EMPTY_NOTICE: NoticeForm = {
+  documentResultAt: '',
+  interviewOpenAt: '',
+  interviewCloseAt: '',
+  finalResultAt: '',
+  interviewNote: '',
+  meetingNote: '',
+  intensiveOpenAt: '',
+  intensiveCloseAt: ''
+}
+
+const toNoticeForm = (notice: RecruitScheduleNotice | null | undefined): NoticeForm => ({
+  documentResultAt: toLocalInput(notice?.documentResultAt),
+  interviewOpenAt: toLocalInput(notice?.interviewOpenAt),
+  interviewCloseAt: toLocalInput(notice?.interviewCloseAt),
+  finalResultAt: toLocalInput(notice?.finalResultAt),
+  interviewNote: notice?.interviewNote ?? '',
+  meetingNote: notice?.meetingNote ?? '',
+  intensiveOpenAt: toLocalInput(notice?.intensiveOpenAt),
+  intensiveCloseAt: toLocalInput(notice?.intensiveCloseAt)
+})
+
+const toNoticePayload = (form: NoticeForm): RecruitScheduleNotice => ({
+  documentResultAt: form.documentResultAt ? toIso(form.documentResultAt) : null,
+  interviewOpenAt: form.interviewOpenAt ? toIso(form.interviewOpenAt) : null,
+  interviewCloseAt: form.interviewCloseAt ? toIso(form.interviewCloseAt) : null,
+  finalResultAt: form.finalResultAt ? toIso(form.finalResultAt) : null,
+  interviewNote: form.interviewNote.trim() || null,
+  meetingNote: form.meetingNote.trim() || null,
+  intensiveOpenAt: form.intensiveOpenAt ? toIso(form.intensiveOpenAt) : null,
+  intensiveCloseAt: form.intensiveCloseAt ? toIso(form.intensiveCloseAt) : null
+})
+
+/** 둘 다 채웠는데 거꾸로면 막는다. 한쪽만 채운 상태는 서버도 허용한다. */
+const reversed = (openAt: string, closeAt: string): boolean =>
+  Boolean(openAt) && Boolean(closeAt) && new Date(openAt) >= new Date(closeAt)
+
+function DateField({
+  label,
+  hint,
+  value,
+  onChange
+}: {
+  label: string
+  hint?: string
+  value: string
+  onChange: (next: string) => void
+}) {
+  return (
+    <DuskField label={label} hint={hint}>
+      <input
+        type="datetime-local"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className={`${DUSK_INPUT} [color-scheme:dark]`}
+      />
+    </DuskField>
+  )
+}
+
+function NoteField({
+  label,
+  hint,
+  value,
+  onChange
+}: {
+  label: string
+  hint: string
+  value: string
+  onChange: (next: string) => void
+}) {
+  return (
+    <DuskField label={label} hint={hint}>
+      <textarea
+        rows={2}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className={DUSK_TEXTAREA}
+      />
+    </DuskField>
+  )
+}
+
 function PeriodEditor({
   recruitType,
   apiClient
@@ -44,20 +147,18 @@ function PeriodEditor({
   const [period, setPeriod] = useState<RecruitPeriodAdmin | null>(null)
   const [openAt, setOpenAt] = useState('')
   const [closeAt, setCloseAt] = useState('')
+  const [notice, setNotice] = useState<NoticeForm>(EMPTY_NOTICE)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [message, setMessage] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  const load = useCallback(
-    async (next?: RecruitPeriodAdmin) => {
-      const result = next ?? (await fetchRecruitPeriod(apiClient, recruitType))
-      setPeriod(result)
-      setOpenAt(toLocalInput(result.openAt))
-      setCloseAt(toLocalInput(result.closeAt))
-    },
-    [apiClient, recruitType]
-  )
+  const apply = (result: RecruitPeriodAdmin) => {
+    setPeriod(result)
+    setOpenAt(toLocalInput(result.openAt))
+    setCloseAt(toLocalInput(result.closeAt))
+    setNotice(toNoticeForm(result.notice))
+  }
 
   useEffect(() => {
     let alive = true
@@ -70,6 +171,7 @@ function PeriodEditor({
         setPeriod(result)
         setOpenAt(toLocalInput(result.openAt))
         setCloseAt(toLocalInput(result.closeAt))
+        setNotice(toNoticeForm(result.notice))
       })
       .catch(() => {
         if (alive) setError('모집 기간을 불러오지 못했습니다.')
@@ -83,10 +185,20 @@ function PeriodEditor({
     }
   }, [apiClient, recruitType])
 
+  const patchNotice = (next: Partial<NoticeForm>) => setNotice({ ...notice, ...next })
+
   const handleSave = async () => {
     if (!openAt || !closeAt) return
     if (new Date(openAt) >= new Date(closeAt)) {
       setError('시작이 마감보다 앞서야 합니다.')
+      return
+    }
+    if (reversed(notice.interviewOpenAt, notice.interviewCloseAt)) {
+      setError('면접 시작이 마감보다 앞서야 합니다.')
+      return
+    }
+    if (reversed(notice.intensiveOpenAt, notice.intensiveCloseAt)) {
+      setError('집중 모집 시작이 마감보다 앞서야 합니다.')
       return
     }
     // 지원 창구를 실제로 여닫는 값이다. 잘못 누르면 지원이 바로 닫히거나 엉뚱한 때 열린다.
@@ -104,10 +216,11 @@ function PeriodEditor({
     try {
       const saved = await updateRecruitPeriod(apiClient, recruitType, {
         openAt: toIso(openAt),
-        closeAt: toIso(closeAt)
+        closeAt: toIso(closeAt),
+        ...toNoticePayload(notice)
       })
-      await load(saved)
-      setMessage('저장했습니다. 지원 판정에 바로 반영됩니다.')
+      apply(saved)
+      setMessage('저장했습니다. 지원 판정과 안내 문구에 바로 반영됩니다.')
     } catch {
       setError('저장에 실패했습니다.')
     } finally {
@@ -116,14 +229,22 @@ function PeriodEditor({
   }
 
   const handleClear = async () => {
-    if (!window.confirm('저장한 기간을 지우고 서버 설정값으로 되돌립니다. 계속할까요?')) return
+    // 되돌리기는 행을 통째로 지운다. 기간만 되돌아가는 것으로 읽히면 발표 날짜가
+    // 사라진 걸 나중에야 알게 되므로 여기서 미리 말한다.
+    if (
+      !window.confirm(
+        '저장한 기간을 지우고 서버 설정값으로 되돌립니다.\n\n아래 안내 일정도 함께 지워지고, 방문자 화면은 배포에 들어 있는 기본값으로 돌아갑니다. 계속할까요?'
+      )
+    ) {
+      return
+    }
 
     setSaving(true)
     setError(null)
     setMessage(null)
     try {
       const restored = await clearRecruitPeriod(apiClient, recruitType)
-      await load(restored)
+      apply(restored)
       setMessage('서버 설정값으로 되돌렸습니다.')
     } catch {
       setError('되돌리지 못했습니다.')
@@ -154,22 +275,71 @@ function PeriodEditor({
       ) : (
         <>
           <div className="grid gap-[18px] [grid-template-columns:repeat(auto-fit,minmax(200px,1fr))]">
-            <DuskField label="시작">
-              <input
-                type="datetime-local"
-                value={openAt}
-                onChange={(event) => setOpenAt(event.target.value)}
-                className={`${DUSK_INPUT} [color-scheme:dark]`}
-              />
-            </DuskField>
-            <DuskField label="마감">
-              <input
-                type="datetime-local"
-                value={closeAt}
-                onChange={(event) => setCloseAt(event.target.value)}
-                className={`${DUSK_INPUT} [color-scheme:dark]`}
-              />
-            </DuskField>
+            <DateField label="시작" value={openAt} onChange={setOpenAt} />
+            <DateField label="마감" value={closeAt} onChange={setCloseAt} />
+          </div>
+
+          {/* 아래부터는 화면에 보이기만 하는 값이다. 위 두 칸과 섞이면 지원이 열린 줄 알고
+              발표 날짜를 지웠다가 창구를 닫아버리는 사고가 난다. */}
+          <div className="mt-2 flex flex-col gap-[18px] border-t border-t-[rgba(240,234,228,0.12)] pt-5">
+            <p className="text-[13px] leading-[1.7] text-dusk-ink-700">
+              아래는 안내 문구입니다. 지원 버튼을 여닫지 않습니다. 비워 두면 배포에 들어 있는
+              기본값이 그대로 보입니다.
+            </p>
+
+            {recruitType === 'CORE' ? (
+              <>
+                <div className="grid gap-[18px] [grid-template-columns:repeat(auto-fit,minmax(200px,1fr))]">
+                  <DateField
+                    label="서류 발표"
+                    hint="자정으로 두면 시각은 안 보인다."
+                    value={notice.documentResultAt}
+                    onChange={(documentResultAt) => patchNotice({ documentResultAt })}
+                  />
+                  <DateField
+                    label="최종 발표"
+                    value={notice.finalResultAt}
+                    onChange={(finalResultAt) => patchNotice({ finalResultAt })}
+                  />
+                  <DateField
+                    label="면접 시작"
+                    value={notice.interviewOpenAt}
+                    onChange={(interviewOpenAt) => patchNotice({ interviewOpenAt })}
+                  />
+                  <DateField
+                    label="면접 마감"
+                    value={notice.interviewCloseAt}
+                    onChange={(interviewCloseAt) => patchNotice({ interviewCloseAt })}
+                  />
+                </div>
+                <NoteField
+                  label="면접 안내 문구"
+                  hint="앞의 ※ 는 화면이 붙인다. 직접 적지 않는다."
+                  value={notice.interviewNote}
+                  onChange={(interviewNote) => patchNotice({ interviewNote })}
+                />
+                <NoteField
+                  label="활동 안내 문구"
+                  hint="지원 안내의 운영진 회의 안내 아래에 붙는다."
+                  value={notice.meetingNote}
+                  onChange={(meetingNote) => patchNotice({ meetingNote })}
+                />
+              </>
+            ) : (
+              <div className="grid gap-[18px] [grid-template-columns:repeat(auto-fit,minmax(200px,1fr))]">
+                <DateField
+                  label="집중 모집 시작"
+                  hint="상시 모집과 별개로 안내만 하는 기간이다."
+                  value={notice.intensiveOpenAt}
+                  onChange={(intensiveOpenAt) => patchNotice({ intensiveOpenAt })}
+                />
+                <DateField
+                  label="집중 모집 마감"
+                  value={notice.intensiveCloseAt}
+                  onChange={(intensiveCloseAt) => patchNotice({ intensiveCloseAt })}
+                />
+              </div>
+            )}
           </div>
 
           {message && <p className="text-[13px] text-signal-ok">{message}</p>}
@@ -202,7 +372,7 @@ function PeriodEditor({
 }
 
 /**
- * 모집 기간.
+ * 모집 일정.
  *
  * 다른 탭과 달리 초안·발행을 거치지 않는다. 저장하는 즉시 지원 판정이 이 값을 본다 —
  * 발행을 기다리는 동안 화면 문구와 실제 동작이 갈라지면 그게 더 위험하다.

--- a/src/components/admin/landing/panels.tsx
+++ b/src/components/admin/landing/panels.tsx
@@ -11,7 +11,7 @@ import {
   DUSK_SELECT,
   DUSK_TEXTAREA
 } from '@/components/ui/dusk/DuskForm'
-import { LANDING_ABOUT_STYLE } from '@/constant/landingContent'
+import { LANDING_ABOUT_STYLE, LANDING_CONTENT_FALLBACK } from '@/constant/landingContent'
 import {
   LANDING_BADGE_TONE_LABEL,
   type LandingActivity,
@@ -36,11 +36,60 @@ const BLANK_PHOTO: LandingPhoto = {
   focusY: 50
 }
 
-function PanelHeading({ title, body }: { title: string; body: string }) {
+const RESET_BUTTON =
+  'shrink-0 rounded-full border border-[rgba(240,234,228,0.22)] px-4 py-2 text-[13px] text-dusk-ink-400 transition-colors hover:border-[rgba(208,129,85,0.6)] hover:text-dusk-ink-100'
+
+/**
+ * 이 탭만 배포에 들어 있는 값으로 되돌린다.
+ *
+ * 사진을 되돌릴 방법이 사실상 이것뿐이다 — 사진 칸은 파일 업로드만 받고 주소를 직접 적을 수
+ * 없어서, 한 번 갈아끼우면 원래 파일을 어디선가 구해 다시 올려야 한다. 기본 사진은 배포 안에
+ * 그대로 들어 있으므로 여기서 되돌리면 아무것도 내려받지 않아도 된다.
+ *
+ * 되돌려도 초안까지다. 방문자에게 나가려면 저장하고 발행해야 한다.
+ */
+function resetSection<K extends keyof LandingContentDocument>(
+  document: LandingContentDocument,
+  onChange: (next: LandingContentDocument) => void,
+  ...keys: K[]
+) {
+  return () => {
+    if (
+      !window.confirm(
+        '이 탭을 배포에 들어 있는 기본값으로 되돌립니다.\n\n여기서 고친 내용은 사라집니다. 계속할까요?'
+      )
+    ) {
+      return
+    }
+
+    const next = { ...document }
+    for (const key of keys) {
+      next[key] = LANDING_CONTENT_FALLBACK[key]
+    }
+    onChange(next)
+  }
+}
+
+function PanelHeading({
+  title,
+  body,
+  onReset
+}: {
+  title: string
+  body: string
+  onReset?: () => void
+}) {
   return (
-    <div>
-      <h1 className="text-2xl font-semibold tracking-[-0.02em]">{title}</h1>
-      <p className="mt-2.5 text-[15px] leading-[1.7] text-dusk-ink-600">{body}</p>
+    <div className="flex flex-wrap items-start justify-between gap-4">
+      <div className="min-w-0">
+        <h1 className="text-2xl font-semibold tracking-[-0.02em]">{title}</h1>
+        <p className="mt-2.5 text-[15px] leading-[1.7] text-dusk-ink-600">{body}</p>
+      </div>
+      {onReset && (
+        <button type="button" onClick={onReset} className={RESET_BUTTON}>
+          기본값으로 되돌리기
+        </button>
+      )}
     </div>
   )
 }
@@ -58,6 +107,7 @@ export function HeroPanel({ document, onChange, apiClient }: PanelProps) {
       <PanelHeading
         title="히어로"
         body="첫 화면 전면에 깔리는 사진과 문구입니다. 사진은 가로가 긴 단체 사진이 잘 맞습니다."
+        onReset={resetSection(document, onChange, 'hero')}
       />
 
       <PhotoField
@@ -130,6 +180,7 @@ export function AboutPanel({ document, onChange }: PanelProps) {
       <PanelHeading
         title="소개"
         body="첫 화면 아래 커뮤니티 소개입니다. 네 칸의 번호와 색은 GDG 4색에 묶여 있어 문구만 바꿉니다."
+        onReset={resetSection(document, onChange, 'about')}
       />
 
       {/* 제목은 두 줄로 끊어 그린다. 한 줄에 몰아 쓰면 좁은 화면에서 아무 데서나 끊긴다. */}
@@ -204,6 +255,7 @@ export function ContactPanel({ document, onChange }: PanelProps) {
       <PanelHeading
         title="문의 · 학기"
         body="바닥글과 FAQ 답변의 연락처, 그리고 첫 화면 배지에 붙는 학기 표기입니다."
+        onReset={resetSection(document, onChange, 'contact', 'semesterLabel')}
       />
 
       <DuskField label="공식 메일">
@@ -252,6 +304,7 @@ export function PhotoStripPanel({ document, onChange, apiClient }: PanelProps) {
       <PanelHeading
         title="사진 띠"
         body="소개와 활동 사이에 들어가는 사진입니다. 최근 행사 사진으로 바꾸면 페이지가 가장 최신처럼 보입니다."
+        onReset={resetSection(document, onChange, 'photoStrip')}
       />
 
       <div className="flex flex-col gap-4">
@@ -297,6 +350,7 @@ export function ActivitiesPanel({ document, onChange }: PanelProps) {
       <PanelHeading
         title="활동"
         body="각 활동의 이름과 설명을 관리합니다. 순서를 바꾸면 페이지에도 그대로 반영됩니다."
+        onReset={resetSection(document, onChange, 'activities')}
       />
 
       <div className="flex flex-col gap-4">
@@ -352,6 +406,7 @@ export function HackathonsPanel({ document, onChange, apiClient }: PanelProps) {
       <PanelHeading
         title="대회 · 해커톤"
         body="목록과 그 옆 사진을 관리합니다. 배지 색은 정해진 세 가지 중에서 고릅니다."
+        onReset={resetSection(document, onChange, 'hackathons')}
       />
 
       <div className="flex flex-col gap-4 rounded-[14px] border border-[rgba(240,234,228,0.12)] p-5">
@@ -488,6 +543,7 @@ export function FaqPanel({ document, onChange }: PanelProps) {
       <PanelHeading
         title="FAQ"
         body="자주 묻는 질문과 답을 관리합니다. 답변은 빈 줄로 문단을 나눕니다 — 문단마다 한 줄로 보입니다."
+        onReset={resetSection(document, onChange, 'faqs')}
       />
 
       <div className="flex flex-col gap-4">

--- a/src/components/admin/landing/panels.tsx
+++ b/src/components/admin/landing/panels.tsx
@@ -11,6 +11,7 @@ import {
   DUSK_SELECT,
   DUSK_TEXTAREA
 } from '@/components/ui/dusk/DuskForm'
+import { LANDING_ABOUT_STYLE } from '@/constant/landingContent'
 import {
   LANDING_BADGE_TONE_LABEL,
   type LandingActivity,
@@ -109,6 +110,132 @@ export function HeroPanel({ document, onChange, apiClient }: PanelProps) {
           type="text"
           value={hero.ctaNote}
           onChange={(event) => patch({ ctaNote: event.target.value })}
+          className={DUSK_INPUT}
+        />
+      </DuskField>
+    </div>
+  )
+}
+
+export function AboutPanel({ document, onChange }: PanelProps) {
+  const { about } = document
+  const patch = (next: Partial<typeof about>) =>
+    onChange({ ...document, about: { ...about, ...next } })
+
+  const patchValue = (index: number, next: Partial<(typeof about.values)[number]>) =>
+    patch({ values: about.values.map((item, i) => (i === index ? { ...item, ...next } : item)) })
+
+  return (
+    <div className="flex flex-col gap-7">
+      <PanelHeading
+        title="소개"
+        body="첫 화면 아래 커뮤니티 소개입니다. 네 칸의 번호와 색은 GDG 4색에 묶여 있어 문구만 바꿉니다."
+      />
+
+      {/* 제목은 두 줄로 끊어 그린다. 한 줄에 몰아 쓰면 좁은 화면에서 아무 데서나 끊긴다. */}
+      <DuskField label="제목 첫 줄">
+        <input
+          type="text"
+          value={about.heading[0] ?? ''}
+          onChange={(event) => patch({ heading: [event.target.value, about.heading[1] ?? ''] })}
+          className={DUSK_INPUT}
+        />
+      </DuskField>
+      <DuskField label="제목 둘째 줄">
+        <input
+          type="text"
+          value={about.heading[1] ?? ''}
+          onChange={(event) => patch({ heading: [about.heading[0] ?? '', event.target.value] })}
+          className={DUSK_INPUT}
+        />
+      </DuskField>
+
+      <DuskField label="소개글">
+        <textarea
+          rows={3}
+          value={about.body}
+          onChange={(event) => patch({ body: event.target.value })}
+          className={DUSK_TEXTAREA}
+        />
+      </DuskField>
+
+      <div className="flex flex-col gap-4">
+        {about.values.map((value, index) => (
+          <div
+            key={index}
+            className="flex flex-col gap-[18px] rounded-[14px] border border-[rgba(240,234,228,0.12)] p-5"
+          >
+            <div className="flex items-baseline gap-2.5">
+              <span className={`text-sm font-medium ${LANDING_ABOUT_STYLE[index]?.colorClass}`}>
+                {LANDING_ABOUT_STYLE[index]?.index}
+              </span>
+              <span className="text-[13px] text-dusk-ink-700">번호와 색은 바꿀 수 없습니다.</span>
+            </div>
+            <DuskField label="제목">
+              <input
+                type="text"
+                value={value.title}
+                onChange={(event) => patchValue(index, { title: event.target.value })}
+                className={DUSK_INPUT}
+              />
+            </DuskField>
+            <DuskField label="설명">
+              <textarea
+                rows={2}
+                value={value.body}
+                onChange={(event) => patchValue(index, { body: event.target.value })}
+                className={DUSK_TEXTAREA}
+              />
+            </DuskField>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function ContactPanel({ document, onChange }: PanelProps) {
+  const { contact } = document
+  const patch = (next: Partial<typeof contact>) =>
+    onChange({ ...document, contact: { ...contact, ...next } })
+
+  return (
+    <div className="flex flex-col gap-7">
+      <PanelHeading
+        title="문의 · 학기"
+        body="바닥글과 FAQ 답변의 연락처, 그리고 첫 화면 배지에 붙는 학기 표기입니다."
+      />
+
+      <DuskField label="공식 메일">
+        <input
+          type="email"
+          value={contact.email}
+          onChange={(event) => patch({ email: event.target.value })}
+          className={DUSK_INPUT}
+        />
+      </DuskField>
+
+      <DuskField label="카카오톡 오픈채팅 주소" hint="https:// 로 시작해야 저장됩니다.">
+        <input
+          type="url"
+          value={contact.openChatUrl}
+          onChange={(event) => patch({ openChatUrl: event.target.value })}
+          className={DUSK_INPUT}
+        />
+      </DuskField>
+
+      {/* FAQ 답변에 적힌 메일 주소는 여기 값과 같을 때만 링크가 걸린다. 답변 문구를 직접
+          바꾸지 않고 주소만 고치면 옛 주소가 글자로 남는다. */}
+      <p className="rounded-[14px] border border-[rgba(240,234,228,0.12)] px-5 py-4 text-[13px] leading-[1.7] text-dusk-ink-700">
+        FAQ 답변 안에 메일 주소를 적어 두셨다면 그쪽도 함께 고쳐 주세요. 답변 문구는 FAQ 탭에서
+        바꿉니다.
+      </p>
+
+      <DuskField label="학기 표기" hint="예: 2026-2. 첫 화면 '부원 모집 중' 앞에 붙는다.">
+        <input
+          type="text"
+          value={document.semesterLabel}
+          onChange={(event) => onChange({ ...document, semesterLabel: event.target.value })}
           className={DUSK_INPUT}
         />
       </DuskField>

--- a/src/components/landing/LandingContentProvider.tsx
+++ b/src/components/landing/LandingContentProvider.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
 
-import { LANDING_CONTENT_FALLBACK } from '@/constant/landingContent'
+import { LANDING_CONTENT_FALLBACK, mergeLandingContent } from '@/constant/landingContent'
 import { fetchLandingContent } from '@/services/landing/landingClient'
 import type { LandingContentDocument } from '@/types/landing'
 
@@ -26,7 +26,8 @@ export function LandingContentProvider({ children }: { children: ReactNode }) {
     fetchLandingContent()
       .then((document) => {
         // 발행된 게 없으면 null 이다. 그때는 기본값을 그대로 둔다.
-        if (alive && document) setContent(document)
+        // 있더라도 통째로 갈아끼우지 않는다 — 나중에 늘어난 칸이 없는 옛 발행본이 있다.
+        if (alive && document) setContent(mergeLandingContent(document))
       })
       .catch(() => {
         // 조용히 넘긴다. 첫 화면에 오류를 띄우는 것보다 예전 내용을 보여주는 편이 낫다.

--- a/src/components/landing/onboarding/AboutSection.tsx
+++ b/src/components/landing/onboarding/AboutSection.tsx
@@ -1,6 +1,11 @@
-import { LANDING_ABOUT } from '@/constant/landingContent'
+'use client'
+
+import { useLandingContent } from '@/components/landing/LandingContentProvider'
+import { LANDING_ABOUT_STYLE } from '@/constant/landingContent'
 
 export default function AboutSection() {
+  const { about } = useLandingContent()
+
   return (
     <section
       id="about"
@@ -10,30 +15,34 @@ export default function AboutSection() {
         data-reveal
         className="max-w-[26ch] break-keep text-[clamp(26px,3.4vw,46px)] font-semibold leading-[1.32] tracking-[-0.03em]"
       >
-        {LANDING_ABOUT.heading[0]}
+        {about.heading[0]}
         <br />
-        {LANDING_ABOUT.heading[1]}
+        {about.heading[1]}
       </h2>
 
       <div
         data-reveal
         className="mt-11 max-w-[62ch] border-l border-l-[rgba(208,129,85,0.55)] pl-5"
       >
-        <p className="break-keep text-base leading-[1.85] text-dusk-ink-400">
-          {LANDING_ABOUT.body}
-        </p>
+        <p className="break-keep text-base leading-[1.85] text-dusk-ink-400">{about.body}</p>
       </div>
 
       <div className="mt-24 grid grid-cols-[repeat(auto-fit,minmax(210px,1fr))] gap-x-8 gap-y-10">
-        {LANDING_ABOUT.values.map((value) => (
-          <div key={value.index} data-reveal>
-            <div className={`text-sm font-medium ${value.colorClass}`}>{value.index}</div>
-            <h3 className="mt-3 text-[21px] font-semibold tracking-[-0.02em]">{value.title}</h3>
-            <p className="mt-2.5 break-keep text-[15px] leading-[1.75] text-dusk-ink-600">
-              {value.body}
-            </p>
-          </div>
-        ))}
+        {/* 번호와 색은 자리 순서로 붙인다. 문구만 관리자가 고치고 개수는 넷으로 고정이다. */}
+        {about.values.map((value, index) => {
+          const style = LANDING_ABOUT_STYLE[index]
+          if (!style) return null
+
+          return (
+            <div key={style.index} data-reveal>
+              <div className={`text-sm font-medium ${style.colorClass}`}>{style.index}</div>
+              <h3 className="mt-3 text-[21px] font-semibold tracking-[-0.02em]">{value.title}</h3>
+              <p className="mt-2.5 break-keep text-[15px] leading-[1.75] text-dusk-ink-600">
+                {value.body}
+              </p>
+            </div>
+          )
+        })}
       </div>
     </section>
   )

--- a/src/components/landing/onboarding/FaqSection.tsx
+++ b/src/components/landing/onboarding/FaqSection.tsx
@@ -3,18 +3,29 @@
 import { Fragment, useState } from 'react'
 
 import { useLandingContent } from '@/components/landing/LandingContentProvider'
-import { GDGOC_EMAIL, GDGOC_OPEN_CHAT_URL } from '@/constant/landingContent'
-import { CORE_SCHEDULE, formatKoreanPeriodShort, MEMBER_SCHEDULE } from '@/constant/recruitSchedule'
+import {
+  CORE_SCHEDULE,
+  formatKoreanPeriodShort,
+  resolveCoreSchedule
+} from '@/constant/recruitSchedule'
+import { useRecruitCorePeriod } from '@/hooks/useRecruitCorePeriod'
+import { useMemberSchedule } from '@/hooks/useRecruitSchedule'
+import type { LandingContact } from '@/types/landing'
 
 /**
  * 답변 안의 연락처를 링크로 만든다. 캡처 그룹이 있는 split 은 구분자도 남기므로
  * 조각을 그대로 훑으면 된다.
+ *
+ * 찾을 주소가 관리자 화면에서 바뀌므로 패턴을 미리 만들어 두지 않는다. 정규식 특수문자를
+ * 그대로 넣으면 엉뚱한 데가 잡히니 이스케이프한다.
  */
-const CONTACT_PATTERN = new RegExp(`(${GDGOC_EMAIL.split('.').join('[.]')}|카카오톡 오픈채팅)`)
+const escapeRegExp = (text: string): string => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
-function renderAnswer(text: string) {
-  return text.split(CONTACT_PATTERN).map((part, index) => {
-    if (part === GDGOC_EMAIL) {
+function renderAnswer(text: string, contact: LandingContact) {
+  const pattern = new RegExp(`(${escapeRegExp(contact.email)}|카카오톡 오픈채팅)`)
+
+  return text.split(pattern).map((part, index) => {
+    if (part === contact.email) {
       return (
         <a key={index} href={`mailto:${part}`} className="text-ember hover:underline">
           {part}
@@ -25,7 +36,7 @@ function renderAnswer(text: string) {
       return (
         <a
           key={index}
-          href={GDGOC_OPEN_CHAT_URL}
+          href={contact.openChatUrl}
           target="_blank"
           rel="noreferrer"
           className="text-ember hover:underline"
@@ -38,37 +49,35 @@ function renderAnswer(text: string) {
   })
 }
 
-/**
- * 모집 일정 문구는 `recruitSchedule.ts` 에서만 가져온다. 여기 날짜를 적어 두면
- * 서버 설정과 갈라져 안내가 틀어진다.
- *
- * 운영진 값은 서버 응답을 못 받았을 때 쓰는 대체값이지만, 랜딩은 안내만 하고
- * 실제 지원 게이팅은 지원 페이지가 서버에 물어보므로 여기서는 대체값을 쓴다.
- */
-function getScheduleCards() {
-  return [
+export default function FaqSection() {
+  const { faqs, contact } = useLandingContent()
+  const { period: corePeriod } = useRecruitCorePeriod()
+  const coreSchedule = resolveCoreSchedule(corePeriod?.notice)
+  const memberSchedule = useMemberSchedule()
+  const [openIndex, setOpenIndex] = useState(-1)
+
+  // 랜딩은 안내만 한다. 실제 지원 게이팅은 지원 페이지가 서버에 물어본다.
+  const coreApplication = corePeriod ?? {
+    openAt: CORE_SCHEDULE.fallbackOpenAt,
+    closeAt: CORE_SCHEDULE.fallbackCloseAt
+  }
+  const scheduleCards = [
     {
       label: '부원 모집',
       value: '상시 모집',
-      note: `집중 모집 ${formatKoreanPeriodShort(MEMBER_SCHEDULE.intensiveOpenAt, MEMBER_SCHEDULE.intensiveCloseAt)}`
+      note: `집중 모집 ${formatKoreanPeriodShort(memberSchedule.intensiveOpenAt, memberSchedule.intensiveCloseAt)}`
     },
     {
       label: '운영진 서류',
-      value: formatKoreanPeriodShort(CORE_SCHEDULE.fallbackOpenAt, CORE_SCHEDULE.fallbackCloseAt),
-      note: `결과 ${CORE_SCHEDULE.documentResult}`
+      value: formatKoreanPeriodShort(coreApplication.openAt, coreApplication.closeAt),
+      note: `결과 ${coreSchedule.documentResult}`
     },
     {
       label: '운영진 면접',
-      value: formatKoreanPeriodShort(CORE_SCHEDULE.interviewOpenAt, CORE_SCHEDULE.interviewCloseAt),
-      note: `최종 발표 ${CORE_SCHEDULE.finalResult}`
+      value: formatKoreanPeriodShort(coreSchedule.interviewOpenAt, coreSchedule.interviewCloseAt),
+      note: `최종 발표 ${coreSchedule.finalResult}`
     }
   ]
-}
-
-export default function FaqSection() {
-  const { faqs } = useLandingContent()
-  const [openIndex, setOpenIndex] = useState(-1)
-  const scheduleCards = getScheduleCards()
 
   return (
     <section id="faq" className="scroll-mt-[68px] border-t border-t-dusk-line-soft">
@@ -111,7 +120,7 @@ export default function FaqSection() {
                   <div className="overflow-hidden">
                     <div className="flex flex-col gap-[7px] break-keep px-1 pb-7 text-[15px] leading-[1.8] text-dusk-ink-600">
                       {faq.answer.map((paragraph) => (
-                        <p key={paragraph}>{renderAnswer(paragraph)}</p>
+                        <p key={paragraph}>{renderAnswer(paragraph, contact)}</p>
                       ))}
                     </div>
                   </div>
@@ -134,7 +143,7 @@ export default function FaqSection() {
           ))}
         </div>
         <p data-reveal className="mt-4 text-[13px] text-dusk-ink-800">
-          {CORE_SCHEDULE.interviewNote}
+          ※ {coreSchedule.interviewNote}
         </p>
 
         <div data-reveal className="mt-16 flex flex-wrap items-baseline justify-between gap-7">

--- a/src/components/landing/onboarding/HeroSection.tsx
+++ b/src/components/landing/onboarding/HeroSection.tsx
@@ -4,13 +4,14 @@ import Image from 'next/image'
 import { useEffect, useRef } from 'react'
 
 import { useLandingContent } from '@/components/landing/LandingContentProvider'
-import { LANDING_SEMESTER_LABEL } from '@/constant/landingContent'
-import { formatKoreanPeriodShort, MEMBER_SCHEDULE } from '@/constant/recruitSchedule'
+import { formatKoreanPeriodShort } from '@/constant/recruitSchedule'
+import { useMemberSchedule } from '@/hooks/useRecruitSchedule'
 
 import { scrollToSection } from './LandingHeader'
 
 export default function HeroSection() {
-  const { hero } = useLandingContent()
+  const { hero, semesterLabel } = useLandingContent()
+  const memberSchedule = useMemberSchedule()
   const contentRef = useRef<HTMLDivElement>(null)
 
   /** 스크롤을 내리는 동안 히어로 문구만 살짝 밀려 올라가며 옅어진다. */
@@ -30,8 +31,8 @@ export default function HeroSection() {
   }, [])
 
   const intensivePeriod = formatKoreanPeriodShort(
-    MEMBER_SCHEDULE.intensiveOpenAt,
-    MEMBER_SCHEDULE.intensiveCloseAt
+    memberSchedule.intensiveOpenAt,
+    memberSchedule.intensiveCloseAt
   )
 
   return (
@@ -79,9 +80,7 @@ export default function HeroSection() {
           <div className="flex shrink-0 flex-col items-start gap-3">
             <div className="flex flex-wrap items-baseline gap-2.5">
               <span aria-hidden className="size-1.5 rounded-full bg-signal-ok" />
-              <span className="text-sm text-dusk-ink-200">
-                {LANDING_SEMESTER_LABEL} 부원 모집 중
-              </span>
+              <span className="text-sm text-dusk-ink-200">{semesterLabel} 부원 모집 중</span>
               <span className="text-sm text-dusk-ink-700">집중 모집 {intensivePeriod}</span>
             </div>
             <a

--- a/src/components/landing/onboarding/LandingFooter.tsx
+++ b/src/components/landing/onboarding/LandingFooter.tsx
@@ -1,8 +1,12 @@
-import { GDGOC_EMAIL, GDGOC_OPEN_CHAT_URL } from '@/constant/landingContent'
+'use client'
+
+import { useLandingContent } from '@/components/landing/LandingContentProvider'
 
 const LINK_CLASS = 'text-dusk-ink-800 transition-colors hover:text-dusk-ink-100'
 
 export default function LandingFooter() {
+  const { contact } = useLandingContent()
+
   return (
     <footer className="flex flex-wrap items-center justify-between gap-5 border-t border-t-dusk-line-soft px-[clamp(20px,5vw,44px)] py-10 text-[13px] text-dusk-ink-800">
       <span>GDGoC INHA · 인하대학교</span>
@@ -10,10 +14,10 @@ export default function LandingFooter() {
         <a href="/board/events/" className={LINK_CLASS}>
           게시판
         </a>
-        <a href={`mailto:${GDGOC_EMAIL}`} className={LINK_CLASS}>
-          {GDGOC_EMAIL}
+        <a href={`mailto:${contact.email}`} className={LINK_CLASS}>
+          {contact.email}
         </a>
-        <a href={GDGOC_OPEN_CHAT_URL} target="_blank" rel="noreferrer" className={LINK_CLASS}>
+        <a href={contact.openChatUrl} target="_blank" rel="noreferrer" className={LINK_CLASS}>
           오픈채팅
         </a>
       </div>

--- a/src/components/recruit/RecruitScheduleCard.tsx
+++ b/src/components/recruit/RecruitScheduleCard.tsx
@@ -1,4 +1,7 @@
-import { CORE_SCHEDULE, formatKoreanPeriod } from '@/constant/recruitSchedule'
+'use client'
+
+import { CORE_SCHEDULE, formatKoreanPeriod, resolveCoreSchedule } from '@/constant/recruitSchedule'
+import { useRecruitCorePeriod } from '@/hooks/useRecruitCorePeriod'
 
 type Props = {
   /** 서버가 내려준 실제 모집 기간. 있으면 이 값으로 렌더해 게이팅과 어긋나지 않게 한다. */
@@ -21,10 +24,15 @@ function Row({ label, value }: { label: string; value: string }) {
  * 칠해야 그 수법이 먹는다. 같은 그림을 테두리로 낸다.
  */
 export function RecruitScheduleCard({ applicationPeriod }: Props) {
-  const period = applicationPeriod ?? {
-    openAt: CORE_SCHEDULE.fallbackOpenAt,
-    closeAt: CORE_SCHEDULE.fallbackCloseAt
-  }
+  // 게이트를 거치지 않고 이 카드만 놓인 화면도 있다. 그때도 서류 접수 날짜가 아래 발표
+  // 날짜와 같은 출처에서 나와야 한다 — 한쪽만 서버 값이면 접수와 발표가 다른 달로 보인다.
+  const { period: corePeriod } = useRecruitCorePeriod()
+  const schedule = resolveCoreSchedule(corePeriod?.notice)
+  const period = applicationPeriod ??
+    corePeriod ?? {
+      openAt: CORE_SCHEDULE.fallbackOpenAt,
+      closeAt: CORE_SCHEDULE.fallbackCloseAt
+    }
   const applicationText = `${formatKoreanPeriod(period.openAt, period.closeAt)} 23:59:59`
 
   return (
@@ -33,11 +41,11 @@ export function RecruitScheduleCard({ applicationPeriod }: Props) {
         <h2 className="text-[15px] font-medium text-dusk-ink-200">모집 일정</h2>
         <div className="mt-3 divide-y divide-[rgba(240,234,228,0.12)] overflow-hidden rounded-[14px] border border-[rgba(240,234,228,0.12)]">
           <Row label="서류 접수" value={applicationText} />
-          <Row label="서류 결과" value={CORE_SCHEDULE.documentResult} />
-          <Row label="면접" value={CORE_SCHEDULE.interview} />
-          <Row label="최종 결과" value={CORE_SCHEDULE.finalResult} />
+          <Row label="서류 결과" value={schedule.documentResult} />
+          <Row label="면접" value={schedule.interview} />
+          <Row label="최종 결과" value={schedule.finalResult} />
           <div className="flex flex-col gap-1.5 px-5 py-[18px] text-[13px] leading-[1.7] text-dusk-ink-800">
-            <span>※ {CORE_SCHEDULE.interviewNote}</span>
+            <span>※ {schedule.interviewNote}</span>
           </div>
         </div>
       </section>
@@ -54,7 +62,7 @@ export function RecruitScheduleCard({ applicationPeriod }: Props) {
         <h2 className="text-[15px] font-medium text-dusk-ink-200">활동 안내</h2>
         <div className="mt-3 flex flex-col gap-1.5 rounded-[14px] border border-[rgba(240,234,228,0.12)] px-5 py-[18px] text-[15px] leading-[1.7] text-dusk-ink-300">
           <p>운영진으로 활동 시, 매주 1회 정기 운영진 회의에 필수 참석해야 합니다.</p>
-          <p className="text-[13px] text-dusk-ink-800">※ {CORE_SCHEDULE.meetingNote}</p>
+          <p className="text-[13px] text-dusk-ink-800">※ {schedule.meetingNote}</p>
         </div>
       </section>
     </div>

--- a/src/constant/landingContent.ts
+++ b/src/constant/landingContent.ts
@@ -1,5 +1,7 @@
 import type {
+  LandingAbout,
   LandingActivity,
+  LandingContact,
   LandingContentDocument,
   LandingFaq,
   LandingHackathon,
@@ -25,7 +27,7 @@ import type {
  * 실제 지원 가능 여부는 서버가 판정한다.
  */
 
-/** 집중 모집 기간 문구 앞에 붙는 학기 표기. `recruitSchedule.ts` 와 함께 고친다. */
+/** 집중 모집 기간 문구 앞에 붙는 학기 표기. 관리자 화면에서 고친다. */
 export const LANDING_SEMESTER_LABEL = '2026-2'
 
 export const LANDING_HERO: LandingHero = {
@@ -43,37 +45,30 @@ export const LANDING_HERO: LandingHero = {
   ctaNote: 'GDGoC INHA와 함께해요.'
 }
 
-export const LANDING_ABOUT = {
+export const LANDING_ABOUT: LandingAbout = {
   heading: ['GDGoC INHA는', '인하대학교의 Google 개발자 커뮤니티예요.'],
   body: 'Google Developer Groups on Campus는 Google이 대학생 개발자 성장을 위해 지원하는 대학 거점형 커뮤니티입니다.',
-  /** 번호 색은 GDG 4색 고정이라 데이터에 함께 둔다. */
   values: [
-    {
-      index: '01',
-      title: '함께',
-      body: '팀으로 배우고 만들며 더 멀리 나아가요.',
-      colorClass: 'text-[#4285F4]'
-    },
-    {
-      index: '02',
-      title: '공유',
-      body: '지식과 경험을 나누며 함께 나아가요.',
-      colorClass: 'text-[#EA4335]'
-    },
-    {
-      index: '03',
-      title: '성장',
-      body: '도전하며 한 단계씩 성장해요.',
-      colorClass: 'text-[#FBBC04]'
-    },
-    {
-      index: '04',
-      title: '존중',
-      body: '서로의 관점과 속도를 존중해요.',
-      colorClass: 'text-[#34A853]'
-    }
+    { title: '함께', body: '팀으로 배우고 만들며 더 멀리 나아가요.' },
+    { title: '공유', body: '지식과 경험을 나누며 함께 나아가요.' },
+    { title: '성장', body: '도전하며 한 단계씩 성장해요.' },
+    { title: '존중', body: '서로의 관점과 속도를 존중해요.' }
   ]
-} as const
+}
+
+/**
+ * 소개 네 칸의 번호와 색.
+ *
+ * 서버로 오가지 않는다. GDG 4색이 자리에 1:1 로 묶여 있어 관리자가 고칠 값이 아니고,
+ * Tailwind 는 소스에 적힌 클래스만 CSS 로 만들기 때문에 DB 에 둬도 색이 안 나온다.
+ * `LANDING_ABOUT.values` 와 **자리 순서로** 짝지으므로 개수를 바꾸지 않는다.
+ */
+export const LANDING_ABOUT_STYLE = [
+  { index: '01', colorClass: 'text-[#4285F4]' },
+  { index: '02', colorClass: 'text-[#EA4335]' },
+  { index: '03', colorClass: 'text-[#FBBC04]' },
+  { index: '04', colorClass: 'text-[#34A853]' }
+] as const
 
 /** 사진 띠 3칸. 관리자 화면에서 추가·삭제·순서 변경이 되므로 개수를 고정하지 않는다. */
 export const LANDING_PHOTO_STRIP: LandingPhoto[] = [
@@ -198,20 +193,42 @@ export const LANDING_FAQS: LandingFaq[] = [
   }
 ]
 
-export const GDGOC_EMAIL = 'gdsc.inha@gmail.com'
-export const GDGOC_OPEN_CHAT_URL = 'https://open.kakao.com/o/s2OqrcIi'
+export const LANDING_CONTACT: LandingContact = {
+  email: 'gdsc.inha@gmail.com',
+  openChatUrl: 'https://open.kakao.com/o/s2OqrcIi'
+}
 
-/**
- * 서버 문서가 없을 때 쓰는 바닥값. 서버 응답과 같은 모양이라 그대로 바꿔 끼울 수 있다.
- *
- * `LANDING_ABOUT`·`LANDING_SEMESTER_LABEL` 은 여기 없다 — 관리자 화면에서 고치지 않는
- * 값이라 서버로 오갈 이유가 없다.
- */
+/** 서버 문서가 없을 때 쓰는 바닥값. 서버 응답과 같은 모양이라 그대로 바꿔 끼울 수 있다. */
 export const LANDING_CONTENT_FALLBACK: LandingContentDocument = {
   hero: LANDING_HERO,
+  about: LANDING_ABOUT,
   photoStrip: LANDING_PHOTO_STRIP,
   activities: LANDING_ACTIVITIES,
   hackathonIntro: LANDING_HACKATHON_INTRO,
   hackathons: LANDING_HACKATHONS,
-  faqs: LANDING_FAQS
+  faqs: LANDING_FAQS,
+  contact: LANDING_CONTACT,
+  semesterLabel: LANDING_SEMESTER_LABEL
 }
+
+/**
+ * 서버 문서를 바닥값 위에 얹는다.
+ *
+ * 통째로 갈아끼우지 않는 이유는 **먼저 발행된 문서에는 나중에 늘어난 칸이 없기** 때문이다.
+ * 소개글·문의 창구·학기 라벨은 뒤에 추가됐고, 그 이전에 발행된 문서를 그대로 쓰면 그 자리가
+ * 비어 화면이 깨진다. 칸 단위로만 얹고 안쪽까지 섞지는 않는다 — 반쯤 섞인 문단이 나오면
+ * 관리자가 화면에서 본 것과 방문자가 보는 것이 갈린다.
+ */
+export const mergeLandingContent = (
+  document: Partial<LandingContentDocument> | null | undefined
+): LandingContentDocument => ({
+  hero: document?.hero ?? LANDING_CONTENT_FALLBACK.hero,
+  about: document?.about ?? LANDING_CONTENT_FALLBACK.about,
+  photoStrip: document?.photoStrip ?? LANDING_CONTENT_FALLBACK.photoStrip,
+  activities: document?.activities ?? LANDING_CONTENT_FALLBACK.activities,
+  hackathonIntro: document?.hackathonIntro ?? LANDING_CONTENT_FALLBACK.hackathonIntro,
+  hackathons: document?.hackathons ?? LANDING_CONTENT_FALLBACK.hackathons,
+  faqs: document?.faqs ?? LANDING_CONTENT_FALLBACK.faqs,
+  contact: document?.contact ?? LANDING_CONTENT_FALLBACK.contact,
+  semesterLabel: document?.semesterLabel ?? LANDING_CONTENT_FALLBACK.semesterLabel
+})

--- a/src/constant/recruitSchedule.ts
+++ b/src/constant/recruitSchedule.ts
@@ -2,8 +2,11 @@
  * 모집 일정 표시용 텍스트.
  *
  * 실제 지원 가능 여부(게이팅)는 서버가 판정한다 — `app.recruit.core.*` 와 `app.recruit.member.*`.
- * 여기 값은 서버 응답을 못 받았을 때 쓰는 대체 문구다. 2차 모집 때 서버 환경변수만 바꾸면
- * 게이팅은 열리지만 아래 문구는 그대로이므로, **일정이 바뀌면 서버 설정과 이 파일을 함께 고친다.**
+ * 여기 값은 서버 응답을 못 받았을 때 쓰는 대체 문구다.
+ *
+ * 발표·면접 날짜는 관리자 화면(`/dashboard/landing/` 모집 일정 탭)에서 고친다. 서버가 값을
+ * 내려주면 그것을 쓰고, 비어 있으면 아래 상수가 그대로 보인다 — `resolveCoreSchedule` 참고.
+ * 그래서 **여기 상수를 고쳐야 하는 경우는 배포 시점의 바닥값을 바꿀 때뿐이다.**
  *
  * 날짜는 전부 ISO 문자열로 두고 아래 포맷터를 거친다. 서버가 준 타임스탬프와 이 파일의
  * 상수가 각자 따로 문자열을 들고 있으면 포맷이 갈린다.
@@ -22,6 +25,22 @@ export function formatKoreanDate(iso: string): string {
   return `${d.getUTCFullYear()}. ${d.getUTCMonth() + 1}. ${d.getUTCDate()}.(${WEEKDAYS[d.getUTCDay()]})`
 }
 
+/**
+ * `2026. 9. 8.(화) 23:59` — 시각까지 정해진 발표·마감용.
+ *
+ * 자정이면 시각을 붙이지 않는다. 관리자가 날짜만 정하고 시각은 신경 쓰지 않았을 때
+ * `2026. 9. 13.(일) 00:00` 이 뜨면 그 시각에 뭔가 있는 것처럼 읽힌다.
+ */
+export function formatKoreanDateTime(iso: string): string {
+  const d = toKst(iso)
+  const hours = d.getUTCHours()
+  const minutes = d.getUTCMinutes()
+  if (hours === 0 && minutes === 0) return formatKoreanDate(iso)
+
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${formatKoreanDate(iso)} ${pad(hours)}:${pad(minutes)}`
+}
+
 /** `8. 10.(월)` — 연도를 뺀 축약형. 카드처럼 폭이 좁은 곳에 쓴다. */
 export function formatKoreanDateShort(iso: string): string {
   const d = toKst(iso)
@@ -38,22 +57,35 @@ export function formatKoreanPeriodShort(openAt: string, closeAt: string): string
   return `${formatKoreanDateShort(openAt)} ~ ${formatKoreanDateShort(closeAt)}`
 }
 
+/**
+ * 서버가 내려주는 안내 일정. 관리자가 저장하지 않은 칸은 `null` 이다.
+ *
+ * 서버의 `RecruitScheduleNotice` 와 같은 모양이다 — **한쪽을 바꾸면 반대쪽도 같은 작업에서
+ * 고쳐야 한다.** 지원 창구를 여닫는 `openAt`/`closeAt` 과 달리 이 값은 화면 문구일 뿐이라
+ * 전부 비어 있어도 정상이다.
+ */
+export type RecruitScheduleNotice = {
+  documentResultAt: string | null
+  interviewOpenAt: string | null
+  interviewCloseAt: string | null
+  finalResultAt: string | null
+  interviewNote: string | null
+  meetingNote: string | null
+  intensiveOpenAt: string | null
+  intensiveCloseAt: string | null
+}
+
 export const CORE_SCHEDULE = {
   /** 서버 응답을 못 받았을 때만 쓰는 대체값. 서버 설정(app.recruit.core.*)과 함께 고친다. */
   fallbackOpenAt: '2026-08-10T00:00:00+09:00',
   fallbackCloseAt: '2026-09-08T23:59:59+09:00',
-  documentResult: '2026. 9. 8.(화) 23:59',
-  /**
-   * 면접 기간. `interview` 는 지원 안내처럼 폭이 넉넉한 곳에 쓰는 전체 표기이고,
-   * 아래 ISO 두 값은 랜딩 3칸처럼 좁은 자리에서 축약형을 만들 때 쓴다.
-   * 셋은 같은 날짜를 가리키므로 일정이 바뀌면 함께 고친다.
-   */
+  documentResultAt: '2026-09-08T23:59:59+09:00',
   interviewOpenAt: '2026-09-09T00:00:00+09:00',
   interviewCloseAt: '2026-09-13T23:59:59+09:00',
-  interview: '2026. 9. 9.(수) - 2026. 9. 13.(일)',
-  interviewNote: '※ 지원자 및 면접관 일정에 따라 마감 전 면접이 가능할 수 있습니다.',
-  finalResult: '2026. 9. 13.(일)',
-  meetingNote: '※ 일정은 9월 내로 공지 드립니다.'
+  finalResultAt: '2026-09-13T00:00:00+09:00',
+  /** 안내 문구는 앞의 `※` 없이 둔다. 붙이는 건 화면이 한다 — 두 번 찍히지 않게. */
+  interviewNote: '지원자 및 면접관 일정에 따라 마감 전 면접이 가능할 수 있습니다.',
+  meetingNote: '일정은 9월 내로 공지 드립니다.'
 } as const
 
 /**
@@ -68,3 +100,53 @@ export const MEMBER_SCHEDULE = {
   intensiveOpenAt: '2026-08-17T00:00:00+09:00',
   intensiveCloseAt: '2026-09-09T23:59:59+09:00'
 } as const
+
+/** 화면이 그대로 쓸 수 있게 다듬은 운영진 일정. */
+export type CoreScheduleView = {
+  /** `2026. 9. 8.(화) 23:59` */
+  documentResult: string
+  interviewOpenAt: string
+  interviewCloseAt: string
+  /** `2026. 9. 9.(수) - 2026. 9. 13.(일)` */
+  interview: string
+  /** `2026. 9. 13.(일)` */
+  finalResult: string
+  /** 앞의 `※` 는 붙어 있지 않다. */
+  interviewNote: string
+  meetingNote: string
+}
+
+export type MemberScheduleView = {
+  intensiveOpenAt: string
+  intensiveCloseAt: string
+}
+
+/**
+ * 서버가 준 안내 일정을 화면 문구로 바꾼다. 비어 있는 칸은 번들 상수로 메운다.
+ *
+ * 칸마다 따로 메우는 이유는 관리자가 일부만 채워도 나머지가 멀쩡히 보여야 하기 때문이다.
+ * 하나라도 비면 통째로 상수를 쓰게 하면, 방금 저장한 값이 화면에 안 나타난다.
+ */
+export function resolveCoreSchedule(notice?: RecruitScheduleNotice | null): CoreScheduleView {
+  const documentResultAt = notice?.documentResultAt ?? CORE_SCHEDULE.documentResultAt
+  const interviewOpenAt = notice?.interviewOpenAt ?? CORE_SCHEDULE.interviewOpenAt
+  const interviewCloseAt = notice?.interviewCloseAt ?? CORE_SCHEDULE.interviewCloseAt
+  const finalResultAt = notice?.finalResultAt ?? CORE_SCHEDULE.finalResultAt
+
+  return {
+    documentResult: formatKoreanDateTime(documentResultAt),
+    interviewOpenAt,
+    interviewCloseAt,
+    interview: formatKoreanPeriod(interviewOpenAt, interviewCloseAt),
+    finalResult: formatKoreanDateTime(finalResultAt),
+    interviewNote: notice?.interviewNote ?? CORE_SCHEDULE.interviewNote,
+    meetingNote: notice?.meetingNote ?? CORE_SCHEDULE.meetingNote
+  }
+}
+
+export function resolveMemberSchedule(notice?: RecruitScheduleNotice | null): MemberScheduleView {
+  return {
+    intensiveOpenAt: notice?.intensiveOpenAt ?? MEMBER_SCHEDULE.intensiveOpenAt,
+    intensiveCloseAt: notice?.intensiveCloseAt ?? MEMBER_SCHEDULE.intensiveCloseAt
+  }
+}

--- a/src/hooks/useRecruitCorePeriod.ts
+++ b/src/hooks/useRecruitCorePeriod.ts
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from 'react'
 
+import type { RecruitScheduleNotice } from '@/constant/recruitSchedule'
+
 export type RecruitCorePeriodStatus = 'BEFORE_OPEN' | 'OPEN' | 'CLOSED'
 
 export type RecruitCorePeriod = {
@@ -9,6 +11,32 @@ export type RecruitCorePeriod = {
   openAt: string
   closeAt: string
   status: RecruitCorePeriodStatus
+  /** 화면에만 쓰는 안내 일정. 예전 서버에는 없으므로 없을 수 있다. */
+  notice?: RecruitScheduleNotice | null
+}
+
+/**
+ * 한 화면에서 여러 컴포넌트가 이 훅을 쓴다. 훅마다 따로 요청하면 첫 화면에서 같은 GET 이
+ * 여러 번 나가므로 진행 중인 요청을 나눠 쓴다. 새로 고치기 전까지는 같은 값을 본다 —
+ * 모집 기간은 보는 동안 바뀌는 값이 아니고, 실제 차단은 서버가 제출 시점에 한다.
+ */
+let inflight: Promise<unknown> | null = null
+
+const load = (): Promise<unknown> => {
+  inflight ??= (async () => {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_API_URL}/recruit/core/period`)
+    if (!response.ok) throw new Error(`status ${response.status}`)
+
+    const body = await response.json()
+    // 응답이 { code, message, data } 로 감싸여 올 수도, 평평하게 올 수도 있다.
+    return body?.data ?? body
+  })().catch((error) => {
+    // 실패한 약속을 남겨두면 다시 열어도 계속 실패한다.
+    inflight = null
+    throw error
+  })
+
+  return inflight
 }
 
 /**
@@ -27,17 +55,11 @@ export function useRecruitCorePeriod() {
 
     const fetchPeriod = async () => {
       try {
-        const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_API_URL}/recruit/core/period`)
-        if (!response.ok) throw new Error(`status ${response.status}`)
-
-        const body = await response.json()
+        const payload = (await load()) as RecruitCorePeriod | undefined
         if (!active) return
-
-        // 응답이 { code, message, data } 로 감싸여 올 수도, 평평하게 올 수도 있다.
-        const payload = body?.data ?? body
         if (!payload?.status) throw new Error('status 없음')
 
-        setPeriod(payload as RecruitCorePeriod)
+        setPeriod(payload)
       } catch (error) {
         if (!active) return
         console.error('[코어 리크루팅] 모집 기간을 불러오지 못했습니다.', error)

--- a/src/hooks/useRecruitMemberPeriod.ts
+++ b/src/hooks/useRecruitMemberPeriod.ts
@@ -2,12 +2,40 @@
 
 import { useEffect, useState } from 'react'
 
+import type { RecruitScheduleNotice } from '@/constant/recruitSchedule'
+
 export type RecruitMemberPeriodStatus = 'BEFORE_OPEN' | 'OPEN' | 'CLOSED'
 
 export type RecruitMemberPeriod = {
   openAt: string
   closeAt: string
   status: RecruitMemberPeriodStatus
+  /** 화면에만 쓰는 안내 일정. 예전 서버에는 없으므로 없을 수 있다. */
+  notice?: RecruitScheduleNotice | null
+}
+
+/**
+ * 한 화면에서 여러 컴포넌트가 이 훅을 쓴다. 훅마다 따로 요청하면 첫 화면에서 같은 GET 이
+ * 여러 번 나가므로 진행 중인 요청을 나눠 쓴다. 새로 고치기 전까지는 같은 값을 본다 —
+ * 모집 기간은 보는 동안 바뀌는 값이 아니고, 실제 차단은 서버가 제출 시점에 한다.
+ */
+let inflight: Promise<unknown> | null = null
+
+const load = (): Promise<unknown> => {
+  inflight ??= (async () => {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_API_URL}/recruit/member/period`)
+    if (!response.ok) throw new Error(`status ${response.status}`)
+
+    const body = await response.json()
+    // 응답이 { code, message, data } 로 감싸여 올 수도, 평평하게 올 수도 있다.
+    return body?.data ?? body
+  })().catch((error) => {
+    // 실패한 약속을 남겨두면 다시 열어도 계속 실패한다.
+    inflight = null
+    throw error
+  })
+
+  return inflight
 }
 
 /**
@@ -29,17 +57,11 @@ export function useRecruitMemberPeriod() {
 
     const fetchPeriod = async () => {
       try {
-        const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_API_URL}/recruit/member/period`)
-        if (!response.ok) throw new Error(`status ${response.status}`)
-
-        const body = await response.json()
+        const payload = (await load()) as RecruitMemberPeriod | undefined
         if (!active) return
-
-        // 응답이 { code, message, data } 로 감싸여 올 수도, 평평하게 올 수도 있다.
-        const payload = body?.data ?? body
         if (!payload?.status) throw new Error('status 없음')
 
-        setPeriod(payload as RecruitMemberPeriod)
+        setPeriod(payload)
       } catch (error) {
         if (!active) return
         console.error('[부원 리크루팅] 모집 기간을 불러오지 못했습니다.', error)

--- a/src/hooks/useRecruitSchedule.ts
+++ b/src/hooks/useRecruitSchedule.ts
@@ -1,0 +1,18 @@
+'use client'
+
+import { resolveMemberSchedule, type MemberScheduleView } from '@/constant/recruitSchedule'
+import { useRecruitMemberPeriod } from '@/hooks/useRecruitMemberPeriod'
+
+/**
+ * 화면에 그대로 그릴 수 있는 집중 모집 기간.
+ *
+ * 서버가 준 값이 있으면 그걸 쓰고, 없으면 번들 상수가 그대로 보인다. 조회에 실패해도
+ * 마찬가지라 화면이 비지 않는다 — 다만 마지막 배포 시점의 일정이 보인다는 뜻이다.
+ *
+ * 운영진 쪽은 이런 훅을 두지 않는다. 부르는 곳마다 접수 기간까지 함께 필요해서
+ * `useRecruitCorePeriod` + `resolveCoreSchedule` 를 직접 쓰는 편이 짧다.
+ */
+export function useMemberSchedule(): MemberScheduleView {
+  const { period } = useRecruitMemberPeriod()
+  return resolveMemberSchedule(period?.notice)
+}

--- a/src/services/landing/landingClient.ts
+++ b/src/services/landing/landingClient.ts
@@ -2,7 +2,7 @@ import type { AxiosInstance } from 'axios'
 
 import { publicClient } from '@/lib/api/publicClient'
 import type { LandingContentDocument } from '@/types/landing'
-import type { RecruitType, RecruitPeriodAdmin } from '@/types/landing.admin'
+import type { RecruitPeriodAdmin, RecruitPeriodUpdate, RecruitType } from '@/types/landing.admin'
 
 /**
  * 응답을 한 겹만 벗긴다. 공용 `unwrapApiResponse` 는 쓰지 않는다 — 문서 안에 'content' 나
@@ -51,7 +51,7 @@ export const fetchRecruitPeriod = async (
 export const updateRecruitPeriod = async (
   apiClient: AxiosInstance,
   recruitType: RecruitType,
-  payload: { openAt: string; closeAt: string }
+  payload: RecruitPeriodUpdate
 ): Promise<RecruitPeriodAdmin> => {
   const response = await apiClient.put(`/admin/recruit/${recruitType}/period`, payload)
   return unwrapOnce<RecruitPeriodAdmin>(response.data)

--- a/src/types/landing.admin.ts
+++ b/src/types/landing.admin.ts
@@ -1,3 +1,5 @@
+import type { RecruitScheduleNotice } from '@/constant/recruitSchedule'
+
 export type RecruitType = 'CORE' | 'MEMBER'
 
 /**
@@ -5,9 +7,19 @@ export type RecruitType = 'CORE' | 'MEMBER'
  *
  * `overridden` 이 false 면 서버 설정값을 쓰고 있다는 뜻이다. 이걸 알아야 '내가 저장한 값이
  * 먹고 있는지'와 '설정값으로 되돌리기'가 의미를 갖는다.
+ *
+ * `notice` 는 화면에만 쓰는 안내 일정이라 `overridden` 과 무관하게 비어 있을 수 있다 —
+ * 기간은 설정값을 쓰면서 발표 날짜만 저장해 둘 수 있다.
  */
 export type RecruitPeriodAdmin = {
   openAt: string
   closeAt: string
   overridden: boolean
+  notice?: RecruitScheduleNotice | null
 }
+
+/** 저장 요청. 기간은 필수, 안내 일정은 비워서 보낼 수 있다. */
+export type RecruitPeriodUpdate = {
+  openAt: string
+  closeAt: string
+} & Partial<RecruitScheduleNotice>

--- a/src/types/landing.ts
+++ b/src/types/landing.ts
@@ -33,6 +33,32 @@ export type LandingHero = {
   ctaNote: string
 }
 
+/**
+ * 소개 네 칸 중 한 칸.
+ *
+ * 번호와 색은 여기 없다 — GDG 4색이 자리에 묶여 있어 `LANDING_ABOUT_STYLE` 이 순서로 붙인다.
+ * 배지 색을 이름으로만 주고받는 것과 같은 이유다.
+ */
+export type LandingAboutValue = {
+  title: string
+  body: string
+}
+
+export type LandingAbout = {
+  /** 두 줄로 끊어 쓴다. 화면에서 첫 줄만 흐린 색으로 그린다. */
+  heading: string[]
+  body: string
+  /** 네 칸 고정. 개수가 바뀌면 번호·색과 어긋난다. */
+  values: LandingAboutValue[]
+}
+
+/** 문의 창구. 바닥글과 FAQ 답변이 같이 쓴다. */
+export type LandingContact = {
+  email: string
+  /** `https://` 로 시작하는 주소만 온다. */
+  openChatUrl: string
+}
+
 export type LandingActivity = {
   title: string
   body: string
@@ -62,11 +88,15 @@ export type LandingFaq = {
 
 export type LandingContentDocument = {
   hero: LandingHero
+  about: LandingAbout
   photoStrip: LandingPhoto[]
   activities: LandingActivity[]
   hackathonIntro: LandingHackathonIntro
   hackathons: LandingHackathon[]
   faqs: LandingFaq[]
+  contact: LandingContact
+  /** 히어로 배지에 붙는 학기 표기. 예: `2026-2`. */
+  semesterLabel: string
 }
 
 /**


### PR DESCRIPTION
배포해야만 바뀌던 문구를 관리자 화면(`/dashboard/landing/`)으로 옮긴다.

## 열린 것

- **소개** 탭(신규) — 제목 두 줄, 소개글, 네 칸의 제목·설명
- **문의 · 학기** 탭(신규) — 공식 메일, 카카오톡 오픈채팅 주소, 학기 표기
- **모집 일정** 탭 — 서류 발표 · 면접 시작/마감 · 최종 발표 · 면접 안내 문구 ·
  활동 안내 문구 · 집중 모집 기간
- 탭마다 **기본값으로 되돌리기** — 사진 칸이 업로드만 받아 한 번 갈아끼우면
  되돌릴 방법이 없었다

## 안전장치

- 서버가 안 준 칸은 번들 상수가 보인다. 아무도 저장하지 않아도 지금 화면이 유지된다.
- 발행본을 통째로 갈아끼우지 않고 칸 단위로 얹는다 — 새 칸이 없던 시절 문서로 안 깨진다.
- 소개 네 칸의 번호·GDG 4색은 고정. 색 클래스를 DB 에 두면 Tailwind 가 CSS 를 안 만든다.

## 고친 것

지원 안내 일정표의 안내 문구가 `※ ※` 로 두 번 찍히고 있었다.

## 확인

- `yarn build` · `yarn lint` · `tsc --noEmit` 통과
- 로컬 스텁으로 저장 → 온보딩·지원 안내 반영, 예전 문서로 열었을 때 기본값 대체까지 클릭 확인
- dev 반영 확인 (배포 전 0건 → 1건): `학기 표기`, `집중 모집 시작`, `기본값으로 되돌리기`
- 서버 짝은 운영 반영 완료 (PR #352)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dp5PH1nxuQMHAmYzC2Y3Mz